### PR TITLE
resolves #358 by removing whitespace from applicant email

### DIFF
--- a/app/assets/javascripts/adoption_app_wizard.js
+++ b/app/assets/javascripts/adoption_app_wizard.js
@@ -29,7 +29,12 @@ $(function(){
               maxlength: 50
             },
             "adopter[email]" : {
-              required: true,
+              required: {
+                depends:function(){
+                  $(this).val($.trim($(this).val()));
+                  return true;
+                }
+              },
               email: true,
                               maxlength: 250,
                               remote: "/adopters/check_email"


### PR DESCRIPTION
tested in Chrome, IE11 and IE9.  Works like a charm