### PR TITLE
resolves #384 error creating comments when not signed in

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,7 @@
 class CommentsController < ApplicationController
+  include SessionsHelper
+
+  before_filter :authenticate
 
   respond_to :html, :json
 


### PR DESCRIPTION
User will now get prompted to reenter credentials.
However it renders in the past comments section instead of
refreshing the page.  Dont thinks its worth ripping the jquery apart to make this elegent.