### PR TITLE
Patches security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'coffee-rails'
 gem 'uglifier'
 
 gem 'chosen-rails', '~> 1.4.3'
-gem 'jquery-rails', '~> 2.0.3'
+gem 'jquery-rails', '~> 3.1.3'
 gem 'jquery-ui-rails', '~> 2.0.2'
 
 gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,9 +178,9 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
-    jquery-rails (2.0.3)
-      railties (>= 3.1.0, < 5.0)
-      thor (~> 0.14)
+    jquery-rails (3.1.4)
+      railties (>= 3.0, < 5.0)
+      thor (>= 0.14, < 2.0)
     jquery-ui-rails (2.0.2)
       jquery-rails
       railties (>= 3.1.0)
@@ -415,7 +415,7 @@ DEPENDENCIES
   gibbon (~> 1.1.1)
   gravatar_image_tag (~> 1.2.0)
   has_scope
-  jquery-rails (~> 2.0.3)
+  jquery-rails (~> 3.1.3)
   jquery-ui-rails (~> 2.0.2)
   json_spec
   mailhopper
@@ -448,4 +448,4 @@ DEPENDENCIES
   will_paginate (~> 3.0.7)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
This patches the security fail reported by Hakiri.  The tests all pass with this version but bumping jquery-rails up to 4.xxx makes tests fail so that makes me believe we're ok here. I'd give a quick manual check just in case though.

Found here:
https://hakiri.io/github/ophrescue/RescueRails/master/54d9c582629e7206899a165a91b4a38d956e4589/warnings?name=Cross-Site+Request+Forgery