### PR TITLE
fixes #463 s3 api error on event photos

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -53,8 +53,7 @@ class Event < ActiveRecord::Base
                  medium: "205x300>",
                  thumb: "64x64>" },
                  path: ":rails_root/public/system/event_photo/:id/:style/:filename",
-                 url: "/system/event_photo/:id/:style/:filename",
-                 s3_permissions: :public_read
+                 url: "/system/event_photo/:id/:style/:filename"
 
 
   validates_attachment_size :photo, less_than: 5.megabytes


### PR DESCRIPTION
caught this in the error logs.  Looks like after the sdk upgrade it's supposed to be ```public-read``` now instead of ```public_read```.  From the paperclip s3 docs, the default is public read anyway, so just deleted the line!