### PR TITLE
Remember infinite scroll position

### DIFF
--- a/app/assets/javascripts/rescue_rails.js
+++ b/app/assets/javascripts/rescue_rails.js
@@ -19,7 +19,7 @@ window.RescueRails = {
       $status.addClass('fa fa-times');
       $status.show();
       $status.fadeOut(3000);
-    })
+    });
   }
 };
 
@@ -28,6 +28,7 @@ $(document).ready(function() {
     $(window).scroll(function() {
       var url = $('ul.pagination .next_page a').attr('href');
       if ((url && url !== '#') && $(window).scrollTop() > $(document).height() - $(window).height() - 300) {
+        window.history.replaceState({}, '', url);
         $('ul.pagination').text("Please Wait...");
         return $.getScript(url);
       }


### PR DESCRIPTION
This method uses the HTML History API and replaces the current url with URL?page=# in the user's history. When the user hits back they'll be on the page they last had load from the infinite scroll but the only way to go back pages is to click the page numbers.

This seems like a good interim solution and is generic enough to work for wherever we're doing infinite scroll currently.

Give her a test ride!