### PR TITLE
Fixes mailto link icon

### DIFF
--- a/vendor/assets/stylesheets/link_icons.scss
+++ b/vendor/assets/stylesheets/link_icons.scss
@@ -15,7 +15,7 @@ a[href $='.docx'] {
 
 a[href ^="mailto:"] {
    padding-right: 20px;
-   background: transparent image-url("icon_mail.gif") no-repeat center right;
+   background: transparent image-url("icon_mailto.gif") no-repeat center right;
 }
 
 a[class ~="popup"] {


### PR DESCRIPTION
During the rails 5 upgrade a test kept failing because icon_mail.gif was
missing.  I'm not sure why rails 4 let this go without reporting a missing image but rails 5 is VERY ANGRY.

Currently broken on production, check out the contact page, https://ophrescue.org/contact

The after

![](https://d3dr1ze7164817.cloudfront.net/items/3G0z3U3G0M0M0l1m171K/Image%202016-08-27%20at%2010.56.56%20PM.png?X-CloudApp-Visitor-Id=2557713&v=0bd2098a)