### PR TITLE
Removes unused json_spec gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ group :development, :test do
   gem 'pry-rails'
   gem 'pry-stack_explorer'
   gem 'rspec-rails'
-  gem 'json_spec'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,9 +171,6 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.3)
-    json_spec (1.1.4)
-      multi_json (~> 1.0)
-      rspec (>= 2.0, < 4.0)
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -412,7 +409,6 @@ DEPENDENCIES
   has_scope
   jquery-rails
   jquery-ui-rails
-  json_spec
   mailhopper
   meta_request
   newrelic_rpm

--- a/spec/features/link_dogs_to_adopters_spec.rb
+++ b/spec/features/link_dogs_to_adopters_spec.rb
@@ -4,7 +4,6 @@ feature 'Link Dogs to Adoption Applications via Adoption model', js: true do
   let!(:test_applicant) { create(:adopter_with_app) }
 
   scenario 'Happy Path' do
-
     admin = create(:user, :admin)
     test_dog = create(:dog)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,6 @@ RSpec.configure do |config|
   config.include LoginMacros
   config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryGirl::Syntax::Methods
-  config.include JsonSpec::Helpers, type: :request
   config.include Rack::Test::Methods, type: :request
 
   # Disable Rails transactional fixtures in favor of DatabaseCleaner


### PR DESCRIPTION
previously in the rails-5 branch, let's dump this thing on its own.