### PR TITLE
fix for #524 renable commit button after post

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -36,6 +36,9 @@ $( function () {
 
         // clear comment field for next comment
         $('#comment_content').val('');
+
+        // Turn the POST button back on
+        $('#comment_submit').prop('disabled', false);
       },
       error: function() {
         alert('error saving comment');

--- a/app/views/adopters/_adopter_comment_form.html.erb
+++ b/app/views/adopters/_adopter_comment_form.html.erb
@@ -1,4 +1,4 @@
 <%= form_for [@adopter, @adopter.comments.build], :html => {:id => "new_comment"} do |f| %>
   <%= f.text_area :content, :class => "input-xxlarge", :rows => "5" %>
-  <%= f.submit "Post", :class => "btn btn-primary" %>
+  <%= f.submit "Post", :id => "comment_submit",:class => "btn btn-primary" %>
 <% end %>

--- a/app/views/dogs/show.html.erb
+++ b/app/views/dogs/show.html.erb
@@ -52,7 +52,7 @@
 
           <%= form_for [@dog, @dog.comments.build], :html => {:id => "new_comment"} do |f| %>
             <%= f.text_area :content, :class => "input-xxlarge", :rows => "6" %>
-            <%= f.submit "Post", :class => "btn btn-primary" %>
+            <%= f.submit "Post", :id => "comment_submit", :class => "btn btn-primary" %>
           <% end %>
 
           <h4>Past Comments</h4>


### PR DESCRIPTION
Was able to verify that for comments on dogs or adopters after a comment was posted, the Post button wouldn't re-enable and folks have to refresh the page for the post button to start working again.

This appears to fix the issue.  Though I'm not sure why it started in the first place, or if there is a cleaner way to handle it.   

Thanks!