### PR TITLE
Fix for InvalidAuthenticityToken Errors

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,10 @@ module RescueRails
     config.active_record.time_zone_aware_types = [:datetime, :time]
 
     config.time_zone = 'Eastern Time (US & Canada)'
+
+     # Resolves InvalidAuthenticityToken errors in Mobile Safari and Mobile Chrome
+     # https://github.com/rails/rails/issues/21948#issuecomment-163995796
+     config.action_dispatch.default_headers.merge!('Cache-Control' => 'no-store, no-cache')
+
   end
 end


### PR DESCRIPTION
in Mobile Safari and Mobile Chrome
Ref https://github.com/rails/rails/issues/21948#issuecomment-163995796

This was originally added in 33ee1fc9c63a3776ae88e349313cdb06fc72f0e0 but is apparently still needed in Rails 5. 

