### PR TITLE
bugfix if logged in only public view dogs should be in gallery view

### DIFF
--- a/app/controllers/dogs_controller.rb
+++ b/app/controllers/dogs_controller.rb
@@ -62,7 +62,9 @@ class DogsController < ApplicationController
   def index
     @title = session[:mgr_view] ? 'Dog Manager' : 'Our Dogs'
 
-    @dogs = DogSearcher.search(params: params, manager: signed_in?)
+    do_manager_view = signed_in? && session[:mgr_view]
+
+    @dogs = DogSearcher.search(params: params, manager: do_manager_view)
 
     respond_to do |format|
       format.html { render :index }


### PR DESCRIPTION
This should fix #553 which was introduced in PR #552 

Gallery view is supposed to work the same regardless of if you're logged in or not.  We introduced an issue where if logged in all dogs ever would show up in the gallery view.  Totally missed that in my review.  

I've added a whole bunch of tests that should verify behavior.  