### PR TITLE
Restores edit form capability

### DIFF
--- a/app/assets/javascripts/adoption_form.js
+++ b/app/assets/javascripts/adoption_form.js
@@ -1,5 +1,33 @@
 $( function() {
   if ( $('.edit-adopter').length > 0) {
+
+    var isEditing = false;
+
+    $('a#toggle-edit').on('click', function(e) {
+      if (isEditing) {
+        // find all disabled fields in .edit-adopter and enable them
+        $('form.edit-adopter .to-disable').attr('disabled', 'disabled');
+        $('.editable').hide();
+        $('.read-only').show();
+        $('a#toggle-edit').addClass('btn-primary').text("Edit Info");
+        $('input.adopter-save').removeClass('btn-primary');
+      }
+      else {
+        $('form.edit-adopter :disabled')
+          .removeAttr('disabled')
+          .addClass('to-disable');
+
+        $('.editable').show();
+        $('.read-only').hide();
+        $('a#toggle-edit').removeClass('btn-primary').text("Cancel");
+        $('input.adopter-save').addClass('btn-primary');
+      }
+
+      isEditing = !isEditing;
+    });
+
+    $('textarea#adopter_dog_name').on('blur', RescueRails.saveParentForm);
+
     var remoteSource = function(request, response) {
       $.getJSON('/dogs?all_dogs=true&search=' + request.term, function(data) {
         var results = [];


### PR DESCRIPTION
No clue how this got removed, must have been when renaming files and such. How has no one noticed this?  You can't edit adopters currently.