### PR TITLE
#437: Add 'country' to user as 3 character string

### DIFF
--- a/db/migrate/20170920014235_add_country_to_user.rb
+++ b/db/migrate/20170920014235_add_country_to_user.rb
@@ -1,0 +1,10 @@
+class AddCountryToUser < ActiveRecord::Migration[5.0]
+  def up
+    add_column :users, :country, :string, limit: 3, comment: 'Country as a ISO 3166-1 alpha-3 code'
+    execute "UPDATE users SET country = 'USA';"
+  end
+
+  def down
+    remove_column :users, :country
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170917020834) do
+ActiveRecord::Schema.define(version: 20170920014235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -352,6 +352,7 @@ ActiveRecord::Schema.define(version: 20170917020834) do
     t.boolean  "translator",                                             default: false, null: false
     t.string   "known_languages",              limit: 255
     t.integer  "code_of_conduct_agreement_id"
+    t.string   "country",                      limit: 3,                                              comment: "Country as a ISO 3166-1 alpha-3 code"
     t.index ["agreement_id"], name: "index_users_on_agreement_id", using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["latitude", "longitude"], name: "index_users_on_latitude_and_longitude", using: :btree


### PR DESCRIPTION
Looking at the schema, it looks like state is either a 2 letter code, as in `banned_adopters`, or a string, as in `adopters` and `users`. Using letter codes is a nice way to have a canonical representation in the database and maintain readability. I've added country as an optional 3 letter code - personally, I find 3 letter country codes easier to read (CAN doesn't look like California). I used the ISO 3166-1 alpha-3 for the US as the value for all legacy data (see comment [here](https://github.com/ophrescue/RescueRails/issues/437#issuecomment-330719943)).

I added a comment on the column, acknowledging that this is inconsistent with the current state. It manifests in both the `schema.rb` and also in the database itself, e.g.:
```
# \d+ users
                                                                                Table "public.users"
            Column            |              Type              |                     Modifiers                      | Storage  | Stats target |             Description              
------------------------------+--------------------------------+----------------------------------------------------+----------+--------------+--------------------------------------
... 
 country                      | character varying(3)           |                                                    | extended |              | Country as a ISO 3166-1 alpha-3 code
