### PR TITLE
#437: Change 'state' to 'region' and 'zip' to 'postal code'

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,9 @@ require 'digest'
 class User < ApplicationRecord
   include Filterable
 
+  alias_attribute :state, :region
+  alias_attribute :zip, :postal_code
+
   attr_accessor :password,
                 :accessible
 

--- a/db/migrate/20170923045153_change_user_address_column_names.rb
+++ b/db/migrate/20170923045153_change_user_address_column_names.rb
@@ -1,0 +1,22 @@
+class ChangeUserAddressColumnNames < ActiveRecord::Migration[5.0] 
+  def up
+    incompatible_records = execute("SELECT id, name, email, state FROM users WHERE LENGTH(state) > 2;")
+    raise "Migration aborted beacuse legacy data contains users with states that are more than two letters: #{incompatible_records.to_a}" unless incompatible_records.to_a.empty?
+    
+    rename_column :users, :state, :region 
+    change_column :users, :region, :string, limit: 2, comment: 'Region (state or province) as a 2 character ISO 3166-2 code' 
+ 
+    rename_column :users, :zip, :postal_code 
+    change_column_comment :users, :postal_code, 'Postal code - ZIP code for US addresses' 
+  end 
+ 
+  def down 
+    rename_column :users, :region, :state 
+    change_column :users, :state, :string, limit: 255, comment: '' 
+ 
+    rename_column :users, :postal_code, :zip 
+    
+    # Remove inapplicable comment
+    change_column_comment :users, :zip, '' 
+  end 
+end 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -308,8 +308,8 @@ ActiveRecord::Schema.define(version: 20170923045153) do
     t.string   "address1",                     limit: 255
     t.string   "address2",                     limit: 255
     t.string   "city",                         limit: 255
-    t.string   "region",                       limit: 255,                                            comment: "Postal region - state or province"
-    t.string   "postal_code",                  limit: 255,                                            comment: "Postal code - ZIP codes for US addresses"
+    t.string   "region",                       limit: 2,                                              comment: "Region (state or province) as a 2 character ISO 3166-2 code"
+    t.string   "postal_code",                  limit: 255,                                            comment: "Postal code - ZIP code for US addresses"
     t.string   "duties",                       limit: 255
     t.boolean  "edit_dogs",                                              default: false
     t.text     "share_info"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170917020834) do
+ActiveRecord::Schema.define(version: 20170923045153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -308,8 +308,8 @@ ActiveRecord::Schema.define(version: 20170917020834) do
     t.string   "address1",                     limit: 255
     t.string   "address2",                     limit: 255
     t.string   "city",                         limit: 255
-    t.string   "state",                        limit: 255
-    t.string   "zip",                          limit: 255
+    t.string   "region",                       limit: 255,                                            comment: "Postal region - state or province"
+    t.string   "postal_code",                  limit: 255,                                            comment: "Postal code - ZIP codes for US addresses"
     t.string   "duties",                       limit: 255
     t.boolean  "edit_dogs",                                              default: false
     t.text     "share_info"


### PR DESCRIPTION
I wanted to see if this makes sense or not before going too far with it - I took a look at what refactoring would be required to fully flesh this out and it's extremely doable so far as I can tell.

**Motivation:**

The desire is to move from supporting exclusively US mailing addresses to supporting international addresses, starting with Canada. Countries are not consistent with how they name their administrative divisions. "Region" appears to be a conventional term for the principal subdivisions of a country - whether they're states, provinces, or other. As a single reference point, see http://schema.org/PostalAddress

Additionally, a ZIP code is a particular type of postal code, but the terminology "ZIP code" is specific to the US, so this changes to use a more generic term.

I find it's generally valuable to make sure the database column names line up with the data that's inside them, otherwise code starts to look crazy quickly, so this seems like a good move with regards to supporting international addresses.

**Concerns:**
- Addresses are not normalized, so the same change would likely be desirable for other representations of the addresses if it is desirable for this one.
- The `User` model has a validation that states must be strictly 2 uppercase characters -  if there was legacy data at some point before this existed or what have you, reducing the field limit like this is "dangerous". I added the `select` at the beginning as a sanity check to make sure the operation is safe - definitely different ways that could be handled though.