### PR TITLE
#437: Change User 'state' to 'region' and 'zip' to 'postal code'

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,8 +31,8 @@
 #  address1                     :string(255)
 #  address2                     :string(255)
 #  city                         :string(255)
-#  state                        :string(255)
-#  zip                          :string(255)
+#  region                       :string(2)
+#  postal_code                  :string(255)
 #  duties                       :string(255)
 #  edit_dogs                    :boolean          default(FALSE)
 #  share_info                   :text
@@ -145,8 +145,8 @@ class UsersController < ApplicationController
                 :address1,
                 :address2,
                 :city,
-                :state,
-                :zip,
+                :region,
+                :postal_code,
                 :duties,
                 :edit_dogs,
                 :share_info,
@@ -215,8 +215,8 @@ class UsersController < ApplicationController
                 :address1,
                 :address2,
                 :city,
-                :state,
-                :zip,
+                :region,
+                :postal_code,
                 :duties,
                 :share_info,
                 :available_to_foster,

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -31,8 +31,8 @@
 #  address1                     :string(255)
 #  address2                     :string(255)
 #  city                         :string(255)
-#  state                        :string(255)
-#  zip                          :string(255)
+#  region                       :string(2)
+#  postal_code                  :string(255)
 #  duties                       :string(255)
 #  edit_dogs                    :boolean          default(FALSE)
 #  share_info                   :text

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,8 +30,8 @@
 #  address1                     :string(255)
 #  address2                     :string(255)
 #  city                         :string(255)
-#  state                        :string(255)
-#  zip                          :string(255)
+#  region                       :string(2)
+#  postal_code                  :string(255)
 #  duties                       :string(255)
 #  edit_dogs                    :boolean          default(FALSE)
 #  share_info                   :text
@@ -81,9 +81,6 @@ require 'digest'
 class User < ApplicationRecord
   include Filterable
 
-  alias_attribute :state, :region
-  alias_attribute :zip, :postal_code
-
   attr_accessor :password,
                 :accessible
 
@@ -98,9 +95,9 @@ class User < ApplicationRecord
                     format: { with: email_regex },
                     uniqueness: { case_sensitive: false }
 
-  validates :state, length: { is: 2 }
+  validates :region, length: { is: 2 }
 
-  validates_format_of :zip,
+  validates_format_of :postal_code,
                     with: /\A\d{5}-\d{4}|\A\d{5}\z/,
                     message: "should be 12345 or 12345-1234",
                     allow_blank: true
@@ -223,11 +220,11 @@ class User < ApplicationRecord
   private
 
     def full_street_address
-      [address1, address2, city, state, zip].compact.join(', ')
+      [address1, address2, city, region, postal_code].compact.join(', ')
     end
 
     def format_cleanup
-      self.state.upcase!
+      self.region.upcase!
       self.email.downcase!
     end
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -62,13 +62,13 @@
     <div class="control-group">
       <%= f.label :state, :class => 'control-label' %>
       <div class="controls">
-        <%= f.text_field :state, :autocomplete => :off %>
+        <%= f.text_field :region, :autocomplete => :off %>
       </div>
     </div>
     <div class="control-group">
       <%= f.label :zip, :class => 'control-label' %>
       <div class="controls">
-        <%= f.text_field :zip, :autocomplete => :off %>
+        <%= f.text_field :postal_code, :autocomplete => :off %>
       </div>
     </div>
     <div class="control-group">

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -5,7 +5,7 @@
   <% end %>
   <td><%= user.duties %></td>
   <td><span class="tel value"><%= user.phone %></span></td>
-  <td><%= user.city %>, <%= user.state %></td>
+  <td><%= user.city %>, <%= user.region %></td>
   <% if params[:foster_mentor] == 'true' %>
     <td>
       <% user.mentees.each do |m| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,8 +23,8 @@
                   <%= @user.address2 %><br />
                 <% end %>
                 <%= @user.city %>,
-                <%= @user.state %>
-                <%= @user.zip %>
+                <%= @user.region %>
+                <%= @user.postal_code %>
             </td>
           </tr>
           <tr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ User.destroy_all
           email: "test@test.com",
           password: "foobar99",
           password_confirmation: "foobar99",
-          state: 'NY'
+          region: 'NY'
 }
 
  user = User.create!(@attr)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -17,8 +17,8 @@
 #  address1                     :string(255)
 #  address2                     :string(255)
 #  city                         :string(255)
-#  state                        :string(255)
-#  zip                          :string(255)
+#  region                       :string(2)
+#  postal_code                  :string(255)
 #  duties                       :string(255)
 #  edit_dogs                    :boolean          default(FALSE)
 #  share_info                   :text

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,8 +6,8 @@ FactoryGirl.define do
     password { Faker::Internet.password(10) }
     address1 { Faker::Address.street_address }
     city { Faker::Address.city }
-    state { Faker::Address.state_abbr }
-    zip { Faker::Address.zip }
+    region { Faker::Address.state_abbr }
+    postal_code { Faker::Address.zip }
     lastverified { Time.now }
 
     trait :admin do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,8 +17,8 @@
 #  address1                     :string(255)
 #  address2                     :string(255)
 #  city                         :string(255)
-#  state                        :string(255)
-#  zip                          :string(255)
+#  region                       :string(2)
+#  postal_code                  :string(255)
 #  duties                       :string(255)
 #  edit_dogs                    :boolean          default(FALSE)
 #  share_info                   :text
@@ -76,29 +76,29 @@ describe User do
 
     context 'with valid fields' do
       it 'should accept a two letter state' do
-        user = build(:user, state: 'PA')
+        user = build(:user, region: 'PA')
         expect(user).to be_valid
       end
-      it 'should accet a 5 digit zipcode' do
-        user = build(:user, zip: '12345')
+      it 'should accept a 5 digit ZIP code' do
+        user = build(:user, postal_code: '12345')
         expect(user).to be_valid
       end
       it 'should save a state abbreviation in all caps' do
-        user = create(:user, state: 'pa')
-        expect(user.state).to eq('PA')
+        user = create(:user, region: 'pa')
+        expect(user.region).to eq('PA')
       end
     end
 
     context 'with invalid fields' do
       it 'is invalid with a state more than 2 letters' do
-        user = build(:user, state: 'Penn')
+        user = build(:user, region: 'Penn')
         user.valid?
-        expect(user.errors[:state]).to include('is the wrong length (should be 2 characters)')
+        expect(user.errors[:region]).to include('is the wrong length (should be 2 characters)')
       end
       it 'is invalid with a zip code of more than 5 characters' do
-        user = build(:user, zip: 'virgina')
+        user = build(:user, postal_code: 'virgina')
         user.valid?
-        expect(user.errors[:zip]).to include('should be 12345 or 12345-1234')
+        expect(user.errors[:postal_code]).to include('should be 12345 or 12345-1234')
       end
     end
   end


### PR DESCRIPTION
Application layer refactor that corresponds to [this database migration](https://github.com/ophrescue/RescueRails/pull/629). The UI is unchanged, so now the field labeled `state` corresponds to the attribute `region` and the field labeled `zip` corresponds to the attribute `postal_code`. This is to support upcoming work that will conditionally change the UI to show localized labels - "Province" and "Postal Code" for Canadian addresses.  