### PR TITLE
fixes #639

### DIFF
--- a/app/models/folder_searcher.rb
+++ b/app/models/folder_searcher.rb
@@ -7,7 +7,7 @@ class FolderSearcher
   def search
     query = 'attachment_file_name ILIKE :search OR description ILIKE :search'
     search = "%#{search_term.strip}%"
-    attachment = Attachment.where(query, search: search).reject do |a|
+    attachment = Attachment.where(attachable_type: 'Folder').where(query, search: search).reject do |a|
       locked_folder?(a) && !@user.dl_locked_resources?
     end.compact
 
@@ -25,7 +25,7 @@ class FolderSearcher
   end
 
   def locked_folder?(a)
-    Folder.find_by_id(a.attachable_id).locked?
+    Folder.find_by(id: a.attachable_id).locked?
   end
 
   # def for_page(page = nil)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -234,8 +234,8 @@ ActiveRecord::Schema.define(version: 20171002180436) do
     t.float    "latitude"
     t.float    "longitude"
     t.date     "event_date"
-    t.time     "start_time"
-    t.time     "end_time"
+    t.time     "start_time",                     precision: 6
+    t.time     "end_time",                       precision: 6
     t.string   "location_url",       limit: 255
     t.string   "location_phone",     limit: 255
     t.string   "photo_file_name",    limit: 255
@@ -352,8 +352,8 @@ ActiveRecord::Schema.define(version: 20171002180436) do
     t.boolean  "translator",                                             default: false, null: false
     t.string   "known_languages",              limit: 255
     t.integer  "code_of_conduct_agreement_id"
-    t.boolean  "medical_behavior_permission",                            default: false
     t.boolean  "boarding_buddies",                                       default: false, null: false
+    t.boolean  "medical_behavior_permission",                            default: false
     t.index ["agreement_id"], name: "index_users_on_agreement_id", using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["latitude", "longitude"], name: "index_users_on_latitude_and_longitude", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -234,8 +234,8 @@ ActiveRecord::Schema.define(version: 20171002180436) do
     t.float    "latitude"
     t.float    "longitude"
     t.date     "event_date"
-    t.time     "start_time",                     precision: 6
-    t.time     "end_time",                       precision: 6
+    t.time     "start_time"
+    t.time     "end_time"
     t.string   "location_url",       limit: 255
     t.string   "location_phone",     limit: 255
     t.string   "photo_file_name",    limit: 255
@@ -352,8 +352,8 @@ ActiveRecord::Schema.define(version: 20171002180436) do
     t.boolean  "translator",                                             default: false, null: false
     t.string   "known_languages",              limit: 255
     t.integer  "code_of_conduct_agreement_id"
-    t.boolean  "boarding_buddies",                                       default: false, null: false
     t.boolean  "medical_behavior_permission",                            default: false
+    t.boolean  "boarding_buddies",                                       default: false, null: false
     t.index ["agreement_id"], name: "index_users_on_agreement_id", using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["latitude", "longitude"], name: "index_users_on_latitude_and_longitude", using: :btree

--- a/spec/models/folder_searcher_spec.rb
+++ b/spec/models/folder_searcher_spec.rb
@@ -10,6 +10,7 @@ describe FolderSearcher do
     let!(:doggie_file) { create(:attachment, attachable_type: 'Folder', attachment_file_name: 'Doggies.pdf', attachable_id: dog_folder_unlocked.id) }
     let!(:dog_folder_locked) { create(:folder, name: 'dog', locked: true) }
     let!(:doggie2_file) { create(:attachment, attachable_type: 'Folder', attachment_file_name: 'Doggies2.pdf', attachable_id: dog_folder_locked.id) }
+    let!(:dog_profile_photo) { create(:attachment, attachable_type: 'Dog', attachment_file_name: 'Doggies.png')}
     let(:params) { { search: 'Doggies' } }
 
     context 'normal user searches for file' do

--- a/spec/models/folder_searcher_spec.rb
+++ b/spec/models/folder_searcher_spec.rb
@@ -7,9 +7,9 @@ describe FolderSearcher do
     let(:restricted_search) { FolderSearcher.search(some_access_user, params: params) }
     let(:unrestricted_search) { FolderSearcher.search(all_access_user, params: params) }
     let!(:dog_folder_unlocked) { create(:folder, name: 'dog', locked: false) }
-    let!(:doggie_file) { create(:attachment, attachment_file_name: 'Doggies.pdf', attachable_id: dog_folder_unlocked.id) }
+    let!(:doggie_file) { create(:attachment, attachable_type: 'Folder', attachment_file_name: 'Doggies.pdf', attachable_id: dog_folder_unlocked.id) }
     let!(:dog_folder_locked) { create(:folder, name: 'dog', locked: true) }
-    let!(:doggie2_file) { create(:attachment, attachment_file_name: 'Doggies2.pdf', attachable_id: dog_folder_locked.id) }
+    let!(:doggie2_file) { create(:attachment, attachable_type: 'Folder', attachment_file_name: 'Doggies2.pdf', attachable_id: dog_folder_locked.id) }
     let(:params) { { search: 'Doggies' } }
 
     context 'normal user searches for file' do


### PR DESCRIPTION
fixes #639
Updated `folder_searcher` to only return `Attachments` that have the `attachable_type` of `Folder`.

Does this solution cause too many queries to the DB?