### PR TITLE
Use rails simplecov configuration

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,3 @@
-require 'simplecov'
-require 'coveralls'
-
-SimpleCov.formatters = [
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
-SimpleCov.start
-
 ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,12 @@
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+SimpleCov.start
+
 RSpec.configure do |config|
   # Use documentation formatter when running a single file.
   config.default_formatter = 'doc' if config.files_to_run.one?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]
-SimpleCov.start
+SimpleCov.start 'rails'
 
 RSpec.configure do |config|
   # Use documentation formatter when running a single file.


### PR DESCRIPTION
This has two separate changes. The simple change is moving the `SimpleCov` initialization code from `rails_helper` to `spec_helper` - `SimpleCov` needs to be `require`'d before any other application code, or it won't be able to track coverage on that code. Practically speaking, this doesn't look like it makes any difference whatsoever with the current implementation, but as `spec_helper` is `require`'d before `rails_helper`, the initialization code should be in `spec_helper`.

Secondly, it looks like we currently use the default configuration of SimpleCov. There's a different configuration for Rails projects that tries to make some sensible decisions about what to test and what not to test. See [documentation](https://github.com/colszowka/simplecov#profiles) for more info. 

I was hoping Coveralls would show a nice view of what had actually changed, but that doesn't look like the case.

What's not included now in the calculation of code coverage (can be added if it's valuable):
- spec files (I don't think this makes sense)
- spec factory classes
- everything in the `config` directory

What's included now in the calculation of code coverage (can be removed if not valuable):
- ruby code in the `lib` directory

Overall, I think this is a more accurate representation of the code coverage, as it's not skewed by all the `100%` coverage on spec files. 