### PR TITLE
437: Validate user country

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rack-cache'
 gem 'acts_as_list'
 gem 'aws-sdk', '~> 2'
 gem 'bootstrap-will_paginate', '~> 0.0.10'
+gem "countries", "~> 2.1"
 gem 'dotenv'
 gem 'dotenv-rails'
 gem 'exception_notification'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,11 @@ GEM
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    countries (2.1.2)
+      i18n_data (~> 0.8.0)
+      money (~> 6.9)
+      sixarm_ruby_unaccent (~> 1.1)
+      unicode_utils (~> 1.4)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
@@ -151,6 +156,7 @@ GEM
       activesupport (>= 4.1, < 5.2)
     hitimes (1.2.6)
     i18n (0.8.6)
+    i18n_data (0.8.0)
     jmespath (1.3.1)
     json (2.1.0)
     kgio (2.11.0)
@@ -171,6 +177,8 @@ GEM
     mini_mime (0.1.4)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    money (6.9.0)
+      i18n (>= 0.6.4, < 0.9)
     multi_json (1.12.2)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -309,6 +317,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    sixarm_ruby_unaccent (1.2.0)
     spreadsheet (1.1.4)
       ruby-ole (>= 1.0)
     sprockets (3.7.1)
@@ -343,6 +352,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
+    unicode_utils (1.4.0)
     unicorn (5.3.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -372,6 +382,7 @@ DEPENDENCIES
   capistrano-rbenv (~> 2.0.3)
   capybara
   capybara-screenshot
+  countries (~> 2.1)
   coveralls
   daemons
   dalli

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,6 @@
 #  social_media_manager         :boolean          default(FALSE)
 #  graphic_design               :boolean          default(FALSE)
 
-
 require 'digest'
 
 class User < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,6 +111,9 @@ class User < ApplicationRecord
                        length: { within: 8..40 },
                        unless: Proc.new { |a| a.password.blank? }
 
+  validates :country, length: { is: 3 }
+  validate :country_is_supported
+
   geocoded_by :full_street_address
   after_validation :geocode
 
@@ -255,5 +258,17 @@ class User < ApplicationRecord
 
     def default_country_to_usa
       self.country ||= "USA"
+    end
+
+    def country_is_supported
+      country = ISO3166::Country.find_country_by_alpha3(self.country)
+      if country.nil?
+        errors.add(:country, "is not recognized.")
+        return
+      end
+
+      unless CountryService.supported_country? country
+        errors.add(:country, "is not supported. Must be one of: #{CountryService.supported_country_names.join(', ')}.")
+      end
     end
 end

--- a/app/services/country_service.rb
+++ b/app/services/country_service.rb
@@ -1,0 +1,13 @@
+require 'countries'
+
+class CountryService
+  SUPPORTED = ISO3166.configuration.locales.map { |locale| ISO3166::Country[locale] }
+
+  def self.supported_country?(country)
+    SUPPORTED.include?(country)
+  end
+
+  def self.supported_country_names
+    SUPPORTED.map(&:name)
+  end
+end

--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -1,0 +1,4 @@
+# Only USA and Canada are supported, so only load the two locales
+ISO3166.configure do |config|
+  config.locales = [:ca, :us]
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,9 +68,22 @@ require 'rails_helper'
 describe User do
   describe '#new' do
     # This test is only valid until international users are supported (#437)
+    # When removed, it's likely appropriate to add a "presence" test
     it 'defaults country to USA' do
       user = User.new
       expect(user.country).to eq('USA')
+    end
+  end
+
+  describe 'valid?' do
+    it 'is invalid when country is not recognized' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'CA', country: 'ZZZ')
+      expect(user).to_not be_valid
+    end
+
+    it 'is invalid when country is not supported' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'CA', country: 'ALB')
+      expect(user).to_not be_valid
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,10 +66,8 @@
 require 'rails_helper'
 
 describe User do
-
-  describe '#new' do 
-
-    # This test is only valid until international users are supported (#437 )
+  describe '#new' do
+    # This test is only valid until international users are supported (#437)
     it 'defaults country to USA' do
       user = User.new
       expect(user.country).to eq('USA')
@@ -87,14 +85,14 @@ describe User do
 
       # Change user's email to trigger the subscription
       user.email = "new_email@test.com"
-      
+
       expect(UserSubscribeJob).to receive(:perform_later)
       user.chimp_check
     end
 
     it 'unsubscribes when user changed to locked' do
       user = create(:user, lastverified: nil, locked: false)
-      
+
       # Lock the user's account to trigger unsubscription
       user.locked = true
 
@@ -104,7 +102,7 @@ describe User do
 
     it 'subscribes when user is changed to unlocked' do
       user = create(:user, lastverified: nil, locked: true)
-      
+
       # Unlock the user's account to trigger subscription
       user.locked = false
 

--- a/spec/services/country_service_spec.rb
+++ b/spec/services/country_service_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe CountryService do
+  describe '.supported_country?' do
+    it 'supports United States' do
+      usa = ISO3166::Country.new('US')
+      expect(CountryService.supported_country?(usa)).to be true
+    end
+
+    it 'supports Canada' do
+      canada = ISO3166::Country.new('CA')
+      expect(CountryService.supported_country?(canada)).to be true
+    end
+
+    it 'does not support other countries' do
+      albania = ISO3166::Country.new('AL')
+      expect(CountryService.supported_country?(albania)).to be false
+    end
+  end
+
+  describe '.supported_country_names' do
+    it 'lists the names' do
+      expect(CountryService.supported_country_names.size).to be CountryService::SUPPORTED.size
+    end
+  end
+end


### PR DESCRIPTION
Adds validation that the country is either `USA` or `CAN`. The behavior to default all users to `USA` if it's not otherwise specified is still in place. Functionally I don't expect this to change anything, it's just another step closer to supporting two different countries. 