### PR TITLE
Add region validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development, :test do
   gem 'pry-doc'
   gem 'pry-rails'
   gem 'pry-stack_explorer'
+  gem 'rspec-collection_matchers'
   gem 'rspec-rails', '3.5.2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,8 @@ GEM
       nokogiri
       rubyzip
       spreadsheet (> 0.6.4)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -419,6 +421,7 @@ DEPENDENCIES
   responders
   rollbar
   roo (~> 1.13.2)
+  rspec-collection_matchers
   rspec-rails (= 3.5.2)
   rubocop
   sass-rails

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,8 +98,6 @@ class User < ApplicationRecord
                     format: { with: email_regex },
                     uniqueness: { case_sensitive: false }
 
-  validates :region, length: { is: 2 }
-
   validates_format_of :postal_code,
                     with: /\A\d{5}-\d{4}|\A\d{5}\z/,
                     message: "should be 12345 or 12345-1234",
@@ -113,6 +111,8 @@ class User < ApplicationRecord
 
   validates :country, length: { is: 3 }
   validate :country_is_supported
+
+  validates_with RegionValidator
 
   geocoded_by :full_street_address
   after_validation :geocode

--- a/app/validators/region_validator.rb
+++ b/app/validators/region_validator.rb
@@ -1,0 +1,43 @@
+class RegionValidator < ActiveModel::Validator
+  PROVINCES = %w[AB BC MB NB NL NS ON PE QC SK NT NU YT].freeze
+
+  def validate(record)
+    country = ISO3166::Country.find_country_by_alpha3(record.country)
+
+    unless country
+      record.errors[:region] << "cannot be validated without a value for country."
+      return
+    end
+
+    if country.eql? ISO3166::Country[:us]
+      validate_state(record)
+    elsif country.eql? ISO3166::Country[:ca]
+      validate_province(record)
+    end
+  end
+
+  private
+
+  def validate_state(record)
+    if record.region.blank?
+      record.errors[:region] << "State cannot be blank."
+      return
+    end
+
+    record.errors[:region] << "State is the wrong length (should be 2 letters)." unless record.region.length == 2
+  end
+
+  def validate_province(record)
+    if record.region.blank?
+      record.errors[:region] << "Province cannot be blank."
+      return
+    end
+
+    unless record.region.length == 2
+      record.errors[:region] << "Province is the wrong length (should be 2 letters)."
+      return
+    end
+
+    record.errors[:region] << "'#{record.region}' is not a valid province." unless PROVINCES.include? record.region
+  end
+end

--- a/app/validators/region_validator.rb
+++ b/app/validators/region_validator.rb
@@ -4,7 +4,7 @@ class RegionValidator < ActiveModel::Validator
   def validate(record)
     country = ISO3166::Country.find_country_by_alpha3(record.country)
 
-    unless country
+    if country.nil?
       record.errors[:region] << "cannot be validated without a value for country."
       return
     end

--- a/spec/features/manage_dogs_spec.rb
+++ b/spec/features/manage_dogs_spec.rb
@@ -8,7 +8,7 @@ feature 'View Dogs', js: true do
   scenario 'View a dog from the public view' do
     visit '/dogs'
     expect(page).to have_content(test_dog.name.titleize)
-    click_link(test_dog.name)
+    click_link(test_dog.name.titleize)
     expect(page).to have_content(test_dog.name.titleize)
   end
 
@@ -17,7 +17,7 @@ feature 'View Dogs', js: true do
     visit '/dogs'
     click_link("Manager View")
     expect(page).to have_content(test_dog.name.titleize)
-    click_link(test_dog.name)
+    click_link(test_dog.name.titleize)
     expect(page).to have_content(test_dog.name.titleize)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -149,7 +149,7 @@ describe User do
       it 'is invalid with a state more than 2 letters' do
         user = build(:user, region: 'Penn')
         user.valid?
-        expect(user.errors[:region]).to include('is the wrong length (should be 2 characters)')
+        expect(user.errors[:region]).to include('State is the wrong length (should be 2 letters).')
       end
       it 'is invalid with a zip code of more than 5 characters' do
         user = build(:user, postal_code: 'virgina')

--- a/spec/validators/region_validator_spec.rb
+++ b/spec/validators/region_validator_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe RegionValidator do
+  class RegionTest
+    include ActiveModel::Validations
+    validates_with RegionValidator
+
+    attr_accessor :country
+    attr_accessor :region
+  end
+
+  describe '#validate' do
+    before :each do
+      @region_test = RegionTest.new
+    end
+
+    it 'requires country to validate' do
+      expect(@region_test).to_not be_valid
+      expect(@region_test).to have_exactly(1).errors_on(:region)
+    end
+
+    context 'in US regions' do
+      before :each do
+        @region_test.country = 'USA'
+      end
+
+      context 'is not valid when' do
+        it 'is fewer than 2 characters' do
+          @region_test.region = ''
+          expect(@region_test).to_not be_valid
+          expect(@region_test).to have_exactly(1).errors_on(:region)
+        end
+
+        it 'is more than 2 characters' do
+          @region_test.region = 'ABC'
+          expect(@region_test).to_not be_valid
+          expect(@region_test).to have_exactly(1).errors_on(:region)
+        end
+      end
+
+      context 'is valid when' do
+        it 'is specified' do
+          # Presently no validation that region is a real state
+          @region_test.region = 'AB'
+          expect(@region_test).to be_valid
+        end
+      end
+    end
+
+    context 'for Candian regions' do
+      before :each do
+        @region_test.country = 'CAN'
+      end
+
+      context 'is not valid when' do
+        it 'is fewer than 2 characters' do
+          @region_test.region = ''
+          expect(@region_test).to_not be_valid
+          expect(@region_test).to have_exactly(1).errors_on(:region)
+        end
+
+        it 'is more than 2 characters' do
+          @region_test.region = 'ABC'
+          expect(@region_test).to_not be_valid
+          expect(@region_test).to have_exactly(1).errors_on(:region)
+        end
+
+        it 'is not a real province' do
+          @region_test.region = 'ZZ'
+          expect(@region_test).to_not be_valid
+          expect(@region_test).to have_exactly(1).errors_on(:region)
+        end
+      end
+
+      context 'is valid when' do
+        it 'is a real province' do
+          @region_test.region = 'AB'
+          expect(@region_test).to be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Continuing the saga of support for Canadian addresses, this introduces validation on the region (state/province) when the country is Canada. The region code is validated to be 2 letters regardless, but when the user has a Canadian address the region is additionally checked to ensure it's actually a province. 