### PR TITLE
#654: Fix user ZIP code validation regex

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,7 +101,7 @@ class User < ApplicationRecord
   validates :region, length: { is: 2 }
 
   validates_format_of :postal_code,
-                    with: /\A\d{5}-\d{4}|\A\d{5}\z/,
+                    with: /\A\d{5}(?:-\d{4})?\z/,
                     message: "should be 12345 or 12345-1234",
                     allow_blank: true
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -148,17 +148,17 @@ describe User do
     context 'with invalid fields' do
       it 'is invalid with a state more than 2 letters' do
         user = build(:user, region: 'Penn')
-        user.valid?
+        expect(user).not_to be_valid
         expect(user.errors[:region]).to include('is the wrong length (should be 2 characters)')
       end
       it 'is invalid with a zip code of more than 5 characters' do
         user = build(:user, postal_code: 'virgina')
-        user.valid?
+        expect(user).not_to be_valid
         expect(user.errors[:postal_code]).to include('should be 12345 or 12345-1234')
       end
-      it 'is invalid with a zip code that starts valid but contains more digits' do
+      it 'is invalid when it starts with a valid zip code but contains extra characters' do
         user = build(:user, postal_code: '12345-12345')
-        user.valid?
+        expect(user).not_to be_valid
         expect(user.errors[:postal_code]).to include('should be 12345 or 12345-1234')
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -156,6 +156,11 @@ describe User do
         user.valid?
         expect(user.errors[:postal_code]).to include('should be 12345 or 12345-1234')
       end
+      it 'is invalid with a zip code that starts valid but contains more digits' do
+        user = build(:user, postal_code: '12345-12345')
+        user.valid?
+        expect(user.errors[:postal_code]).to include('should be 12345 or 12345-1234')
+      end
     end
   end
 


### PR DESCRIPTION
Before this fix is merged, the production database should be checked for invalid data. For example, anything returned by:
`SELECT id, name, email, postal_code FROM users WHERE postal_code !~ '\A\Z|\A\d{5}(?:-\d{4})?\Z';`
will be invalid after this has been merged.

Fixes #654. The regular expression used was missing the terminating character in the first alternative expression. This means that any value could be used for the ZIP so long as it started with 5 digits followed by 4 digits.