### PR TITLE
437: Add validator for postal code

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,11 +98,6 @@ class User < ApplicationRecord
                     format: { with: email_regex },
                     uniqueness: { case_sensitive: false }
 
-  validates_format_of :postal_code,
-                    with: /\A\d{5}(?:-\d{4})?\z/,
-                    message: "should be 12345 or 12345-1234",
-                    allow_blank: true
-
   # Automatically creates the virtual attribute 'password_confirmation'.
   validates :password, presence: true,
                        confirmation: true,
@@ -113,6 +108,7 @@ class User < ApplicationRecord
   validate :country_is_supported
 
   validates_with RegionValidator
+  validates_with PostalCodeValidator
 
   geocoded_by :full_street_address
   after_validation :geocode

--- a/app/validators/postal_code_validator.rb
+++ b/app/validators/postal_code_validator.rb
@@ -1,0 +1,23 @@
+class PostalCodeValidator < ActiveModel::Validator
+  ZIP_CODE_REGEX = /\A\d{5}(?:-\d{4})?\z/
+  POSTAL_CODE_REGEX = /\A[ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9]\Z/
+
+  def validate(record)
+    return if record.postal_code.blank?
+
+    country = ISO3166::Country.find_country_by_alpha3(record.country)
+
+    unless country
+      record.errors[:postal_code] << "cannot be validated without a value for country."
+      return
+    end
+
+    postal_code = record.postal_code.delete(' ').upcase
+
+    if country.eql?(ISO3166::Country[:us]) && !postal_code.match(ZIP_CODE_REGEX)
+      record.errors[:postal_code] << "should be 12345 or 12345-1234"
+    elsif country.eql?(ISO3166::Country[:ca]) && !postal_code.match(POSTAL_CODE_REGEX)
+      record.errors[:postal_code] << "is not valid"
+    end
+  end
+end

--- a/spec/validators/postal_code_validator_spec.rb
+++ b/spec/validators/postal_code_validator_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe PostalCodeValidator do
       end
     end
 
-    context 'for Candian addresses' do
+    context 'for Canadian addresses' do
       before :each do
         @postal_code_test.country = 'CAN'
       end

--- a/spec/validators/postal_code_validator_spec.rb
+++ b/spec/validators/postal_code_validator_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe PostalCodeValidator do
+  class PostalCodeTest
+    include ActiveModel::Validations
+    validates_with PostalCodeValidator
+
+    attr_accessor :country
+    attr_accessor :postal_code
+  end
+
+  describe '#validate' do
+    before :each do
+      @postal_code_test = PostalCodeTest.new
+    end
+
+    it 'can be blank' do
+      expect(@postal_code_test).to be_valid
+    end
+
+    it 'requires country if not blank' do
+      @postal_code_test.postal_code = "12345"
+      expect(@postal_code_test).to_not be_valid
+      expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+    end
+
+    context 'for US addresses' do
+      before :each do
+        @postal_code_test.country = 'USA'
+      end
+
+      context 'is not valid when' do
+        it 'is fewer than 5 digits' do
+          @postal_code_test.postal_code = '1234'
+          expect(@postal_code_test).to_not be_valid
+          expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+        end
+
+        it 'is between 5 and 9 digits' do
+          @postal_code_test.postal_code = '123456'
+          expect(@postal_code_test).to_not be_valid
+          expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+        end
+
+        it 'is more than 9 digits' do
+          @postal_code_test.postal_code = '12345-12345'
+          expect(@postal_code_test).to_not be_valid
+          expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+        end
+
+        it 'is 9 digits without a dash' do
+          @postal_code_test.postal_code = '123451234'
+          expect(@postal_code_test).to_not be_valid
+          expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+        end
+      end
+
+      context 'is valid when' do
+        it 'is 5 digits' do
+          @postal_code_test.postal_code = '12345'
+          expect(@postal_code_test).to be_valid
+        end
+
+        it 'is 5 digits then a dash then 4 digits' do
+          @postal_code_test.postal_code = '12345-1234'
+          expect(@postal_code_test).to be_valid
+        end
+      end
+    end
+
+    context 'for Candian addresses' do
+      before :each do
+        @postal_code_test.country = 'CAN'
+      end
+
+      context 'is not valid when' do
+        it 'it is not a postal code' do
+          @postal_code_test.postal_code = 'not-real'
+          expect(@postal_code_test).to_not be_valid
+          expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+        end
+
+        it 'it is an invalid postal code' do
+          @postal_code_test.postal_code = 'W0W0W0'
+          expect(@postal_code_test).to_not be_valid
+          expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+        end
+
+        it 'it is 5 characters' do
+          @postal_code_test.postal_code = 'K1R2R'
+          expect(@postal_code_test).to_not be_valid
+          expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+        end
+
+        it 'it is 7 characters' do
+          @postal_code_test.postal_code = 'K1R2R2R'
+          expect(@postal_code_test).to_not be_valid
+          expect(@postal_code_test).to have_exactly(1).errors_on(:postal_code)
+        end
+      end
+
+      context 'is valid when' do
+        it 'is 6 valid characters' do
+          @postal_code_test.postal_code = 'K1K2K2'
+          expect(@postal_code_test).to be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As the final piece of Canadian address validation, this introduces a postal code validator for both US ZIP codes and Canadian postal codes. Validation remains the same as before for US addresses (with the quirk that it can't be validated if the country isn't specified), and it validates only that it's the right form for Canadian postal codes. I didn't look at all at code to check it's a real postal code. 