### PR TITLE
#437: Sanitize postal code before validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -258,8 +258,8 @@ class User < ApplicationRecord
     end
 
     def sanitize_postal_code
-      return unless self.postal_code
-      self.postal_code = self.postal_code.delete(' ').upcase
+      return if postal_code.blank?
+      self.postal_code = postal_code.delete(' ').upcase
     end
 
     def country_is_supported

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -137,6 +137,7 @@ class User < ApplicationRecord
   belongs_to :mentor, class_name: 'User', foreign_key: 'mentor_id'
   has_many :mentees, class_name: 'User', foreign_key: 'mentor_id'
 
+  before_validation :sanitize_postal_code
   before_save :format_cleanup
   before_create :chimp_subscribe
   before_update :chimp_check
@@ -254,6 +255,11 @@ class User < ApplicationRecord
 
     def default_country_to_usa
       self.country ||= "USA"
+    end
+
+    def sanitize_postal_code
+      return unless self.postal_code
+      self.postal_code = self.postal_code.delete(' ').upcase
     end
 
     def country_is_supported

--- a/app/validators/postal_code_validator.rb
+++ b/app/validators/postal_code_validator.rb
@@ -1,6 +1,6 @@
 class PostalCodeValidator < ActiveModel::Validator
-  ZIP_CODE_REGEX = /\A\d{5}(?:-\d{4})?\z/
-  POSTAL_CODE_REGEX = /\A[ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9]\Z/
+  VALID_US_ZIP_CODE = /\A\d{5}(?:-\d{4})?\z/
+  VALID_CANADIAN_POSTAL_CODE = /\A[ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9]\Z/
 
   def validate(record)
     return if record.postal_code.blank?
@@ -12,9 +12,9 @@ class PostalCodeValidator < ActiveModel::Validator
       return
     end
 
-    if country.eql?(ISO3166::Country[:us]) && !record.postal_code.match(ZIP_CODE_REGEX)
+    if country.eql?(ISO3166::Country[:us]) && !record.postal_code.match(VALID_US_ZIP_CODE)
       record.errors[:postal_code] << "should be 12345 or 12345-1234"
-    elsif country.eql?(ISO3166::Country[:ca]) && !record.postal_code.match(POSTAL_CODE_REGEX)
+    elsif country.eql?(ISO3166::Country[:ca]) && !record.postal_code.match(VALID_CANADIAN_POSTAL_CODE)
       record.errors[:postal_code] << "is not valid"
     end
   end

--- a/app/validators/postal_code_validator.rb
+++ b/app/validators/postal_code_validator.rb
@@ -12,11 +12,9 @@ class PostalCodeValidator < ActiveModel::Validator
       return
     end
 
-    postal_code = record.postal_code.delete(' ').upcase
-
-    if country.eql?(ISO3166::Country[:us]) && !postal_code.match(ZIP_CODE_REGEX)
+    if country.eql?(ISO3166::Country[:us]) && !record.postal_code.match(ZIP_CODE_REGEX)
       record.errors[:postal_code] << "should be 12345 or 12345-1234"
-    elsif country.eql?(ISO3166::Country[:ca]) && !postal_code.match(POSTAL_CODE_REGEX)
+    elsif country.eql?(ISO3166::Country[:ca]) && !record.postal_code.match(POSTAL_CODE_REGEX)
       record.errors[:postal_code] << "is not valid"
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,6 +85,30 @@ describe User do
       user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'CA', country: 'ALB')
       expect(user).to_not be_valid
     end
+
+    it 'removes whitespace from Canadian postal codes' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'ON', country: 'CAN')
+      user.postal_code = "   K 2 J 0 A     1   "
+
+      expect(user).to be_valid
+      expect(user.postal_code).to eq('K2J0A1')
+    end
+
+    it 'removes whitespace from American ZIP codes' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'CA', country: 'USA')
+      user.postal_code = " 12    3 4 5   "
+
+      expect(user).to be_valid
+      expect(user.postal_code).to eq('12345')
+    end
+
+    it 'converts postal codes to uppercase' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'ON', country: 'CAN')
+      user.postal_code = "k2j0a1"
+
+      expect(user).to be_valid
+      expect(user.postal_code).to eq('K2J0A1')
+    end
   end
 
   describe '#chimp_check' do


### PR DESCRIPTION
Fixes bug I accidentally introduced in [this PR](https://github.com/ophrescue/RescueRails/pull/657). The validation I introduced was operating on a manipulated version of the model's attribute. This sanitizes the postal code (removes whitespace and converts letters to upper case) before validation.