### PR TITLE
437 add country to user form

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,8 +171,6 @@ class User < ApplicationRecord
   scope :puppies_ok,              -> (status = true) { where(can_foster_puppies: status) }
   scope :has_parvo_house,         -> (status = true) { where(parvo_house: status) }
 
-  after_initialize :default_country_to_usa
-
   def has_password?(submitted_password)
     encrypted_password == encrypt(submitted_password)
   end
@@ -253,10 +251,6 @@ class User < ApplicationRecord
 
     def secure_hash(string)
       Digest::SHA2.hexdigest(string)
-    end
-
-    def default_country_to_usa
-      self.country ||= "USA"
     end
 
     def sanitize_postal_code

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -258,8 +258,8 @@ class User < ApplicationRecord
     end
 
     def sanitize_postal_code
-      return unless self.postal_code
-      self.postal_code = self.postal_code.delete(' ').upcase
+      return if postal_code.blank?
+      self.postal_code = postal_code.delete(' ').upcase
     end
 
     def country_is_supported

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -137,6 +137,7 @@ class User < ApplicationRecord
   belongs_to :mentor, class_name: 'User', foreign_key: 'mentor_id'
   has_many :mentees, class_name: 'User', foreign_key: 'mentor_id'
 
+  before_validation :sanitize_postal_code
   before_save :format_cleanup
   before_create :chimp_subscribe
   before_update :chimp_check
@@ -254,6 +255,11 @@ class User < ApplicationRecord
 
     def default_country_to_usa
       self.country ||= "USA"
+    end
+
+    def sanitize_postal_code
+      return unless self.postal_code
+      self.postal_code = self.postal_code.delete(' ').upcase
     end
 
     def country_is_supported

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,6 +138,8 @@ class User < ApplicationRecord
   has_many :mentees, class_name: 'User', foreign_key: 'mentor_id'
 
   before_validation :sanitize_postal_code
+  before_validation :sanitize_region
+
   before_save :format_cleanup
   before_create :chimp_subscribe
   before_update :chimp_check
@@ -260,6 +262,11 @@ class User < ApplicationRecord
     def sanitize_postal_code
       return if postal_code.blank?
       self.postal_code = postal_code.delete(' ').upcase
+    end
+
+    def sanitize_region
+      return if region.blank?
+      self.region = region.delete(' ').upcase
     end
 
     def country_is_supported

--- a/app/validators/postal_code_validator.rb
+++ b/app/validators/postal_code_validator.rb
@@ -1,6 +1,6 @@
 class PostalCodeValidator < ActiveModel::Validator
-  ZIP_CODE_REGEX = /\A\d{5}(?:-\d{4})?\z/
-  POSTAL_CODE_REGEX = /\A[ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9]\Z/
+  VALID_US_ZIP_CODE = /\A\d{5}(?:-\d{4})?\z/
+  VALID_CANADIAN_POSTAL_CODE = /\A[ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9]\Z/
 
   def validate(record)
     return if record.postal_code.blank?
@@ -12,9 +12,9 @@ class PostalCodeValidator < ActiveModel::Validator
       return
     end
 
-    if country.eql?(ISO3166::Country[:us]) && !record.postal_code.match(ZIP_CODE_REGEX)
+    if country.eql?(ISO3166::Country[:us]) && !record.postal_code.match(VALID_US_ZIP_CODE)
       record.errors[:postal_code] << "should be 12345 or 12345-1234"
-    elsif country.eql?(ISO3166::Country[:ca]) && !record.postal_code.match(POSTAL_CODE_REGEX)
+    elsif country.eql?(ISO3166::Country[:ca]) && !record.postal_code.match(VALID_CANADIAN_POSTAL_CODE)
       record.errors[:postal_code] << "is not valid"
     end
   end

--- a/app/validators/postal_code_validator.rb
+++ b/app/validators/postal_code_validator.rb
@@ -12,11 +12,9 @@ class PostalCodeValidator < ActiveModel::Validator
       return
     end
 
-    postal_code = record.postal_code.delete(' ').upcase
-
-    if country.eql?(ISO3166::Country[:us]) && !postal_code.match(ZIP_CODE_REGEX)
+    if country.eql?(ISO3166::Country[:us]) && !record.postal_code.match(ZIP_CODE_REGEX)
       record.errors[:postal_code] << "should be 12345 or 12345-1234"
-    elsif country.eql?(ISO3166::Country[:ca]) && !postal_code.match(POSTAL_CODE_REGEX)
+    elsif country.eql?(ISO3166::Country[:ca]) && !record.postal_code.match(POSTAL_CODE_REGEX)
       record.errors[:postal_code] << "is not valid"
     end
   end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -60,15 +60,21 @@
       </div>
     </div>
     <div class="control-group">
-      <%= f.label :state, :class => 'control-label' %>
+      <%= f.label :state, 'State/Province', class: 'control-label' %>
       <div class="controls">
         <%= f.text_field :region, :autocomplete => :off %>
       </div>
     </div>
     <div class="control-group">
-      <%= f.label :zip, :class => 'control-label' %>
+      <%= f.label :postal_code, 'ZIP/Postal Code', class: 'control-label' %>
       <div class="controls">
         <%= f.text_field :postal_code, :autocomplete => :off %>
+      </div>
+    </div>
+    <div class="control-group">
+      <%= f.label :country, :class => 'control-label' %>
+      <div class="controls">
+        <%= f.select :country, [['USA', ISO3166::Country[:us].alpha3], ['Canada', ISO3166::Country[:ca].alpha3]], selected: @user.country || ISO3166::Country[:us].alpha3 %>
       </div>
     </div>
     <div class="control-group">

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,16 +66,15 @@
 require 'rails_helper'
 
 describe User do
-  describe '#new' do
-    # This test is only valid until international users are supported (#437)
-    # When removed, it's likely appropriate to add a "presence" test
-    it 'defaults country to USA' do
-      user = User.new
-      expect(user.country).to eq('USA')
-    end
-  end
-
   describe 'valid?' do
+    it 'requires country' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'CA')
+      expect(user).to_not be_valid
+
+      user.country = 'USA'
+      expect(user).to be_valid
+    end
+
     it 'is invalid when country is not recognized' do
       user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'CA', country: 'ZZZ')
       expect(user).to_not be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,6 +85,30 @@ describe User do
       user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'CA', country: 'ALB')
       expect(user).to_not be_valid
     end
+
+    it 'removes whitespace from Canadian postal codes' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'ON', country: 'CAN')
+      user.postal_code = "   K 2 J 0 A     1   "
+
+      expect(user).to be_valid
+      expect(user.postal_code).to eq('K2J0A1')
+    end
+
+    it 'removes whitespace from American ZIP codes' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'CA', country: 'USA')
+      user.postal_code = " 12    3 4 5   "
+
+      expect(user).to be_valid
+      expect(user.postal_code).to eq('12345')
+    end
+
+    it 'converts postal codes to uppercase' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'ON', country: 'CAN')
+      user.postal_code = "k2j0a1"
+
+      expect(user).to be_valid
+      expect(user.postal_code).to eq('K2J0A1')
+    end
   end
 
   describe '#chimp_check' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -109,6 +109,20 @@ describe User do
       expect(user).to be_valid
       expect(user.postal_code).to eq('K2J0A1')
     end
+
+    it 'converts Canadian province to uppercase' do
+      user = User.new(name: Faker::Name.name, email: 'test@example.com', region: 'on', country: 'CAN')
+
+      expect(user).to be_valid
+      expect(user.region).to eq('ON')
+    end
+
+    it 'converts American state to uppercase' do
+      user = User.new(region: 'on', name: Faker::Name.name, email: 'test@example.com', country: 'USA')
+
+      expect(user).to be_valid
+      expect(user.region).to eq('ON')
+    end
   end
 
   describe '#chimp_check' do


### PR DESCRIPTION
Incorporates PR #661, so hoping that gets merged shortly. This adds the country to the `user` form. I went for the easiest UI I could think of for the first pass.

![image](https://user-images.githubusercontent.com/3683198/32147019-66117584-bcb6-11e7-8eac-d50f11783169.png)