### PR TITLE
#580: Add not-null constraints to email and encrypted password

### DIFF
--- a/db/migrate/20171115013311_add_not_null_to_user_email_and_password.rb
+++ b/db/migrate/20171115013311_add_not_null_to_user_email_and_password.rb
@@ -1,0 +1,6 @@
+class AddNotNullToUserEmailAndPassword < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null(:users, :email, false)
+    change_column_null(:users, :encrypted_password, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010004452) do
+ActiveRecord::Schema.define(version: 20171115013311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -295,10 +295,10 @@ ActiveRecord::Schema.define(version: 20171010004452) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                         limit: 255
-    t.string   "email",                        limit: 255
+    t.string   "email",                        limit: 255,                               null: false
     t.datetime "created_at",                               precision: 6
     t.datetime "updated_at",                               precision: 6
-    t.string   "encrypted_password",           limit: 255
+    t.string   "encrypted_password",           limit: 255,                               null: false
     t.string   "salt",                         limit: 255
     t.boolean  "admin",                                                  default: false
     t.string   "password_reset_token",         limit: 255


### PR DESCRIPTION
Exactly what it sounds like, email and password are used to sign in so they can't be `null`. Enforce that at the database by adding the `NOT NULL` constraint. I imagine data that does not meet these requirements could be found with e.g.

`SELECT id, name, email, encrypted_password FROM users WHERE email IS NULL OR encrypted_password IS NULL;`

I would hope that nothing is returned by that query, if there is then we'll need to figure out why.