### PR TITLE
580: Add user tests

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,12 +186,6 @@ class User < ApplicationRecord
     (user && user.salt == cookie_salt) ? user : nil
   end
 
-  def generate_token(column)
-    begin
-      self[column] = SecureRandom.urlsafe_base64
-    end while User.exists?(column => self[column])
-  end
-
   def out_of_date?
     lastverified.blank? || (lastverified.to_date < 30.days.ago.to_date)
   end
@@ -226,6 +220,12 @@ class User < ApplicationRecord
   end
 
   private
+
+    def generate_token(column)
+      begin
+        self[column] = SecureRandom.urlsafe_base64
+      end while User.exists?(column => self[column])
+    end
 
     def full_street_address
       [address1, address2, city, region, postal_code].compact.join(', ')


### PR DESCRIPTION
The current authentication and session logic is not particularly well covered by specs. Wrote some specs to understand the current behavior to make it easier to switch to Devise without regressions.

Also noticed that `generate_token` is only used within `User`, so easier to make it private than write specs for it!