### PR TITLE
Remove admin privileges from regular user context

### DIFF
--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -7,9 +7,9 @@ RSpec.shared_context 'signed in admin' do
 end
 
 RSpec.shared_context 'signed in user' do
-  let(:admin) { create(:user, :admin) }
+  let(:user) { create(:user) }
 
   before do
-    allow(controller).to receive(:current_user) { admin }
+    allow(controller).to receive(:current_user) { user }
   end
 end


### PR DESCRIPTION
Tiny piece of the puzzle I found while looking at all the test failures I have locally when I tried cutting over to Devise.

There are two shared contexts defined, an admin context and a regular user context. Before this change, despite being named differently they were the same. It seems like the intention is that a "user" does not have admin privileges, so this strips the admin privileges.