### PR TITLE
change mouse cursor to move only when it is over something movable

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -211,12 +211,12 @@ th .desc {
 #photos_sort {
   font-size: 12px;
   color: #777;
-  cursor: move;
 }
 
 td.sort-handle {
   vertical-align: middle;
   text-align: right;
+  cursor: move;
 }
 
 #edit_flag select,


### PR DESCRIPTION
The cursor was switching to move when it wasn't over the actual 'move handle' for the dog photo sort.  This was causing a lot of confusion.  