### PR TITLE
install audited with jsonb support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
 bundler_args: --without production
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
   chrome: stable
 
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', '5.0.3'
 gem 'rack-cache'
 
 gem 'acts_as_list'
+gem 'audited', '~> 4.5'
 gem 'aws-sdk', '~> 2'
 gem 'bootstrap-will_paginate', '~> 0.0.10'
 gem "countries"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       io-like (~> 0.3.0)
     arel (7.1.4)
     ast (2.3.0)
+    audited (4.5.0)
+      activerecord (>= 4.0, < 5.2)
     aws-sdk (2.10.94)
       aws-sdk-resources (= 2.10.94)
     aws-sdk-core (2.10.94)
@@ -391,6 +393,7 @@ PLATFORMS
 DEPENDENCIES
   acts_as_list
   annotate
+  audited (~> 4.5)
   aws-sdk (~> 2)
   better_errors
   binding_of_caller

--- a/db/migrate/20171221012248_install_audited.rb
+++ b/db/migrate/20171221012248_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :jsonb
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_id, :auditable_type], :name => 'auditable_index'
+    add_index :audits, [:associated_id, :associated_type], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171103212000) do
+ActiveRecord::Schema.define(version: 20171221012248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,28 @@ ActiveRecord::Schema.define(version: 20171103212000) do
     t.datetime "updated_at",                          null: false
     t.text     "description"
     t.string   "agreement_type"
+  end
+
+  create_table "audits", force: :cascade do |t|
+    t.integer  "auditable_id"
+    t.string   "auditable_type"
+    t.integer  "associated_id"
+    t.string   "associated_type"
+    t.integer  "user_id"
+    t.string   "user_type"
+    t.string   "username"
+    t.string   "action"
+    t.jsonb    "audited_changes"
+    t.integer  "version",         default: 0
+    t.string   "comment"
+    t.string   "remote_address"
+    t.string   "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_id", "associated_type"], name: "associated_index", using: :btree
+    t.index ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
+    t.index ["created_at"], name: "index_audits_on_created_at", using: :btree
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
+    t.index ["user_id", "user_type"], name: "user_index", using: :btree
   end
 
   create_table "banned_adopters", force: :cascade do |t|


### PR DESCRIPTION
Humble Beginnings for #682 

This gets our audited gem installed and audit table created using the jsonb datatype introduced in Postgresql 9.4.

Initial testing of audited shows that implementation is pretty easy, most of the work will be on getting the views to look good. 