### PR TITLE
corrected spouse_name validation to be 50 chars

### DIFF
--- a/app/assets/javascripts/adoption_app_wizard.js
+++ b/app/assets/javascripts/adoption_app_wizard.js
@@ -70,7 +70,7 @@ $(function(){
                               maxlength: 250
                         },
                         "adopter[adoption_app_attributes][spouse_name]" : {
-                              maxlength: 250
+                              maxlength: 50
                         },
                         "adopter[adoption_app_attributes][other_household_names]" : {
                               maxlength: 250

--- a/app/models/adoption_app.rb
+++ b/app/models/adoption_app.rb
@@ -63,7 +63,7 @@ class AdoptionApp < ApplicationRecord
   validates :ready_to_adopt_dt, presence: true
   validates :dog_stay_when_away, presence: true, length: { maximum: 100 }
   validates :landlord_name, allow_blank: true, length: { maximum: 100 }
-  validates :spouse_name, allow_blank: true, length: { maximum: 255 }
+  validates :spouse_name, allow_blank: true, length: { maximum: 50 }
   validates :other_household_names, allow_blank: true, length: { maximum: 255 }
   validates :how_did_you_hear, allow_blank: true, length: { maximum: 255 }
 end


### PR DESCRIPTION
The spouse_name database column is only 50 chars.  Validations were set too long.    