### PR TITLE
redirect tracking for  5k registration

### DIFF
--- a/app/views/pages/5k.html.erb
+++ b/app/views/pages/5k.html.erb
@@ -1,0 +1,24 @@
+<script>
+    var redirectCallback = function() {
+        window.location.href = "https://www.active.com/frederick-md/running/distance-running-races/4th-annual-fast-and-furriest-5k-1m-fun-walk-event-2018"
+    };
+    ga('send', 'pageview', {
+        'hitCallback': redirectCallback
+    });
+</script>
+
+<script type="text/javascript">
+    // Redirect after 2 seconds in case the analytics call didn't finish
+    window.setTimeout(redirectCallback, 2000);
+</script>
+
+
+<div class="row-fluid">
+  <div class="span10">
+
+    <h1>4th Annual Fast and Furriest Registration</h1>
+
+    <p>Redirecting to you our <a hef="https://www.active.com/frederick-md/running/distance-running-races/4th-annual-fast-and-furriest-5k-1m-fun-walk-event-2018">registration page</a>.</p>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ RescueRails::Application.routes.draw do
 
   root                         to: 'pages#home'
 
-  get '/5k',                   to: redirect('https://www.active.com/frederick-md/running/distance-running-races/4th-annual-fast-and-furriest-5k-1m-fun-walk-event-2018')
+  get '5k',                    to: 'pages#5k'
 
   get '/signin',               to: 'sessions#new'
   get '/signout',              to: 'sessions#destroy'


### PR DESCRIPTION
The 5k promotion team is starting a social media campaign for the upcoming OPH 5k.  They'd like to be able to track visitors to the `/5k` link via Google Analytics.  

This change creates an actual page which should provide some time for Google Analytics to fire off and collect the event and related details.    Suggestions on if there is a better way to pull this off are appreciated.  