### PR TITLE
Bugfix/email notifications

### DIFF
--- a/app/views/adopters/_adopter_references.html.erb
+++ b/app/views/adopters/_adopter_references.html.erb
@@ -1,1 +1,1 @@
-<%= render 'references/reference' %>
+<%= render 'references/references_form' %>

--- a/app/views/references/_reference.html.erb
+++ b/app/views/references/_reference.html.erb
@@ -1,46 +1,17 @@
-<%= form_for @adopter, html: { class: 'form-horizontal edit-reference' } do |f| %>
-  <%= f.fields_for :references, f.object.references.order(:name) do |rf| %>
-    <table class="table table-striped table-bordered table-condensed">
-      <tr>
-        <th class="span2">Name</th>
-        <td>
-          <div class='ref-read-only'><%= rf.object.name %></div>
-          <div class='ref-editable'><%= rf.text_field :name %></div>
-        </td>
-      </tr>
-      <tr>
-        <th>Phone</th>
-        <td>
-          <div class='ref-read-only'><span class="tel value"><%= rf.object.phone %></span></div>
-          <div class='ref-editable'><%= rf.text_field :phone %></div>
-        </td>
-      </tr>
-      <tr>
-        <th>E-mail</th>
-        <td>
-          <div class='ref-read-only'><%= rf.object.email %></div>
-          <div class='ref-editable'><%= rf.text_field :email %></div>
-        </td>
-      </tr>
-      <tr>
-        <th>Relationship</th>
-        <td>
-          <div class='ref-read-only'><%= rf.object.relationship %></div>
-          <div class='ref-editable'><%= rf.text_field :relationship %></div>
-        </td>
-      </tr>
-      <tr>
-        <th>When to Call</th>
-        <td>
-          <div class='ref-read-only'><%= rf.object.whentocall %></div>
-          <div class='ref-editable'><%= rf.text_field :whentocall %></div>
-        </td>
-      </tr>
-    </table>
-      <% end %>
-  <p>
-    <a id="toggle-edit-ref" class="btn btn-primary">Edit References</a>
-    <%= f.submit "Save References", class: "btn reference-save", disabled: "disabled" %>
-  </p>
-
-<% end %>
+<tr>
+  <td>
+    <%= reference.name %>
+  </td>
+  <td>
+    <span class="tel value"><%= reference.phone %></span>
+  </td>
+  <td>
+    <%= reference.email %>
+  </td>
+  <td>
+    <%= reference.relationship %>
+  </td>
+  <td>
+    <%= reference.whentocall %>
+  </td>
+</tr>

--- a/app/views/references/_references_form.html.erb
+++ b/app/views/references/_references_form.html.erb
@@ -1,0 +1,46 @@
+<%= form_for @adopter, html: { class: 'form-horizontal edit-reference' } do |f| %>
+  <%= f.fields_for :references, f.object.references.order(:name) do |rf| %>
+    <table class="table table-striped table-bordered table-condensed">
+      <tr>
+        <th class="span2">Name</th>
+        <td>
+          <div class='ref-read-only'><%= rf.object.name %></div>
+          <div class='ref-editable'><%= rf.text_field :name %></div>
+        </td>
+      </tr>
+      <tr>
+        <th>Phone</th>
+        <td>
+          <div class='ref-read-only'><span class="tel value"><%= rf.object.phone %></span></div>
+          <div class='ref-editable'><%= rf.text_field :phone %></div>
+        </td>
+      </tr>
+      <tr>
+        <th>E-mail</th>
+        <td>
+          <div class='ref-read-only'><%= rf.object.email %></div>
+          <div class='ref-editable'><%= rf.text_field :email %></div>
+        </td>
+      </tr>
+      <tr>
+        <th>Relationship</th>
+        <td>
+          <div class='ref-read-only'><%= rf.object.relationship %></div>
+          <div class='ref-editable'><%= rf.text_field :relationship %></div>
+        </td>
+      </tr>
+      <tr>
+        <th>When to Call</th>
+        <td>
+          <div class='ref-read-only'><%= rf.object.whentocall %></div>
+          <div class='ref-editable'><%= rf.text_field :whentocall %></div>
+        </td>
+      </tr>
+    </table>
+      <% end %>
+  <p>
+    <a id="toggle-edit-ref" class="btn btn-primary">Edit References</a>
+    <%= f.submit "Save References", class: "btn reference-save", disabled: "disabled" %>
+  </p>
+
+<% end %>

--- a/spec/features/apply_to_adopt_spec.rb
+++ b/spec/features/apply_to_adopt_spec.rb
@@ -99,6 +99,7 @@ feature 'Apply for Adoption' do
     fill_in('adopter_references_attributes_2_whentocall', with: 'After 3pm')
 
     expect { click_button('Submit') }.to change { Adopter.count }.by(1)
+      .and change { ActionMailer::Base.deliveries.size }.by(2)
 
     expect(page).to have_content 'Success! Your adoption application has been submitted'
 
@@ -255,6 +256,7 @@ feature 'Apply for Adoption' do
     fill_in('adopter_references_attributes_2_whentocall', with: 'After 3pm')
 
     expect { click_button('Submit') }.to change { Adopter.count }.by(1)
+      .and change { ActionMailer::Base.deliveries.size }.by(2)
 
     expect(page).to have_content 'Success! Your adoption application has been submitted'
 

--- a/spec/mailers/adopt_app_mailer_spec.rb
+++ b/spec/mailers/adopt_app_mailer_spec.rb
@@ -3,30 +3,30 @@ require 'rails_helper'
 describe NewAdopterMailer, type: :mailer do
   include ActiveJob::TestHelper
 
-  describe "Application Received! Email" do
+  describe "PLEASE REPLY Application Email" do
     let(:adopter) { create(:adopter_with_app) }
 
     it 'job is created' do
       ActiveJob::Base.queue_adapter = :test
       expect do
-        NewAdopterMailer.adopter_created(adopter.id).deliver_later
+        AdoptAppMailer.adopt_app(adopter.id).deliver_later
       end.to have_enqueued_job.on_queue('mailers')
     end
 
     it 'welcome_email is sent' do
       expect do
         perform_enqueued_jobs do
-          NewAdopterMailer.adopter_created(adopter.id).deliver_later
+          AdoptAppMailer.adopt_app(adopter.id).deliver_later
         end
       end.to change { ActionMailer::Base.deliveries.size }.by(1)
     end
 
     it 'welcome_email is sent to the right user' do
       perform_enqueued_jobs do
-        NewAdopterMailer.adopter_created(adopter.id).deliver_later
+        AdoptAppMailer.adopt_app(adopter.id).deliver_later
       end
       mail = ActionMailer::Base.deliveries.last
-      expect(mail.to[0]).to eq adopter.email
+      expect(mail.reply_to[0]).to eq adopter.email
     end
   end
 end

--- a/spec/mailers/new_adopter_mailer_spec.rb
+++ b/spec/mailers/new_adopter_mailer_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe NewAdopterMailer, type: :mailer do
+  include ActiveJob::TestHelper
+
+  describe "Application Received! Email" do
+    let(:adopter) { create(:adopter_with_app) }
+
+    it 'job is created' do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        NewAdopterMailer.adopter_created(adopter.id).deliver_later
+      end.to have_enqueued_job.on_queue('mailers')
+    end
+
+    it 'welcome_email is sent' do
+      expect do
+        perform_enqueued_jobs do
+          NewAdopterMailer.adopter_created(adopter.id).deliver_later
+        end
+      end.to change { ActionMailer::Base.deliveries.size }.by(1)
+    end
+
+    it 'welcome_email is sent to the right user' do
+      perform_enqueued_jobs do
+        NewAdopterMailer.adopter_created(adopter.id).deliver_later
+      end
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to[0]).to eq adopter.email
+    end
+  end
+
+  describe "PLEASE REPLY Application Email" do
+    let(:adopter) { create(:adopter_with_app) }
+
+    it 'job is created' do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        AdoptAppMailer.adopt_app(adopter.id).deliver_later
+      end.to have_enqueued_job.on_queue('mailers')
+    end
+
+    it 'welcome_email is sent' do
+      expect do
+        perform_enqueued_jobs do
+          AdoptAppMailer.adopt_app(adopter.id).deliver_later
+        end
+      end.to change { ActionMailer::Base.deliveries.size }.by(1)
+    end
+
+    it 'welcome_email is sent to the right user' do
+      perform_enqueued_jobs do
+        AdoptAppMailer.adopt_app(adopter.id).deliver_later
+      end
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.reply_to[0]).to eq adopter.email
+    end
+  end
+end


### PR DESCRIPTION
connects to #740 

AdoptAppMailer nows renders and sends again

AdoptAppMailer and adopter view both depended on the same
renderer for references.  When that was changed into a form it
stopped rendering correctly in email.
Moved the edit reference form to a new file
Put the old reference render back in place for the email to use
Added new tests to catch similar problems in the future.