### PR TITLE
closes #769 fix autocomplete for password change

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -315,13 +315,13 @@
     <div class="control-group">
       <%= f.label :password, :class => 'control-label' %>
       <div class="controls">
-        <%= f.password_field :password, :autocomplete => :off %>
+        <%= f.password_field :password, :autocomplete => 'new-password' %>
       </div>
     </div>
     <div class="control-group">
       <%= f.label :password_confirmation, :class => 'control-label' %>
       <div class="controls">
-        <%= f.password_field :password_confirmation, :autocomplete => :off %>
+        <%= f.password_field :password_confirmation, :autocomplete => 'new-password' %>
       </div>
     </div>
 


### PR DESCRIPTION
connects to #769

Should help with Browsers trying to autocomplete the change password fields. 

