### PR TITLE
Users prefer dog manager to have no statuses set by default

### DIFF
--- a/app/views/dogs/_manager.html.erb
+++ b/app/views/dogs/_manager.html.erb
@@ -77,7 +77,7 @@
           <i class="fa fa-filter" aria-hidden="true"></i> Filter
         <% end %>
 
-        <%= link_to '<i class="fa fa-times-circle-o" aria-hidden="true"></i> Reset '.html_safe, :controller => "dogs", :action => "manager_index", :is_status => Dog::ACTIVE_STATUSES %>
+        <%= link_to '<i class="fa fa-times-circle-o" aria-hidden="true"></i> Reset '.html_safe, :controller => "dogs", :action => "manager_index" %>
 
       <% end %>
     </div>

--- a/app/views/dogs/index.html.erb
+++ b/app/views/dogs/index.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="span4 offset4">
     <% if current_user&.active %>
-      <%= link_to("Manager View", {:controller => 'dogs', :action => 'manager_index', :is_status => Dog::ACTIVE_STATUSES},:class => "btn ") %>
+      <%= link_to("Manager View", {:controller => 'dogs', :action => 'manager_index'},:class => "btn ") %>
     <% end %>
   </div>
 </div>

--- a/app/views/dogs/show.html.erb
+++ b/app/views/dogs/show.html.erb
@@ -2,7 +2,7 @@
     <div class="span12">
       <h5><%= link_to "Available Dogs", :controller => "dogs", :status => "active"  %></h5>
       <% if current_user&.active %>
-        <h5><%= link_to "Dog Manager", :controller => "dogs", :action => "manager_index", :is_status => Dog::ACTIVE_STATUSES %></h5>
+        <h5><%= link_to "Dog Manager", :controller => "dogs", :action => "manager_index" %></h5>
       <% end %>
       <h1><%= @dog.name %></h1>
       <h3><%= @dog.primary_breed.name if @dog.primary_breed.present? %></h3>

--- a/app/views/layouts/_topbar.html.erb
+++ b/app/views/layouts/_topbar.html.erb
@@ -70,7 +70,7 @@
                     <% end %>
                     <% if current_user.active? || current_user.admin? %>
                       <li><%= link_to "DNA List", :controller => "banned_adopters" %></li>
-                      <li><%= link_to "Dog Manager", :controller => "dogs", :action => "manager_index", :is_status => Dog::ACTIVE_STATUSES %></li>
+                      <li><%= link_to "Dog Manager", :controller => "dogs", :action => "manager_index" %></li>
                       <li><%= link_to "Users", users_path %></li>
                     <% end %>
                     <% if can_dl_resources? %>


### PR DESCRIPTION
Had multiple feedback requests to adjust Dog Manager default view to not have any statuses set by default.  