### PR TITLE
remove find_definitions as it causes rake failures

### DIFF
--- a/lib/tasks/populate_db.rake
+++ b/lib/tasks/populate_db.rake
@@ -35,7 +35,6 @@ namespace :rescue_rails do
 
   desc "populate users"
   task populate_users: :environment do
-    FactoryBot.find_definitions
     User.destroy_all
     FactoryBot.create(:user, :admin, :with_known_authentication_parameters)
     25.times do


### PR DESCRIPTION
I don't know why the error didn't show up before. FactoryBot.find_definitions is called during initialization, it causes errors to call it again.
(No production code changed in this PR, it can be safely merged)