### PR TITLE
fixes issue where flash persists to the next request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage
 .powenv
 .vscode/
 .byebug_history
+site_notes.txt

--- a/app/controllers/dogs_controller.rb
+++ b/app/controllers/dogs_controller.rb
@@ -112,7 +112,7 @@ class DogsController < ApplicationController
 
   def show
     @title = @dog.name
-    flash[:error]= render_to_string partial: 'unavailable_flash_message' if @dog.unavailable?
+    flash.now[:error]= render_to_string partial: 'unavailable_flash_message' if @dog.unavailable?
   end
 
   def new


### PR DESCRIPTION
I just noticed that the flash refactor I did previously was allowing the "dog unavailable" message to persist onto the next request.