### PR TITLE
fixes occasional errors in apply_to_adopt_spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage
 .powenv
 .vscode/
 .byebug_history
+site_notes.txt

--- a/spec/features/apply_to_adopt_spec.rb
+++ b/spec/features/apply_to_adopt_spec.rb
@@ -5,7 +5,8 @@ feature 'Apply for Adoption' do
 
   scenario "Renter fills out adoption application", js: true do
     visit root_path
-    click_link 'Apply for Adoption'
+    click_link 'Adopt'
+    click_link 'Adoption Application'
     check('adopter_pre_q_costs')
     check('adopter_pre_q_surrender')
     check('adopter_pre_q_abuse')
@@ -172,7 +173,8 @@ feature 'Apply for Adoption' do
 
   scenario "Home Owner fills out adoption application", js: true do
     visit root_path
-    click_link 'Apply for Adoption'
+    click_link 'Adopt'
+    click_link 'Adoption Application'
     check('adopter_pre_q_costs')
     check('adopter_pre_q_surrender')
     check('adopter_pre_q_abuse')


### PR DESCRIPTION
The errors are due to the fact that the spec attempts to get to the adoption application by way of the link that cycles through as part of the front page image carousel. So there's a chance that it will not appear in time to be clicked from the spec.

This PR instead navigates to the adoption application via the nav bar menu.