### PR TITLE
seed Faker random from RSpec seed, facilitate repro of dog sort anomalies

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,15 @@
 require 'simplecov'
 require 'coveralls'
 require "rack_session_access/capybara"
+require 'faker'
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]
 SimpleCov.start 'rails'
+
+Faker::Config.random = Random.new(RSpec.configuration.seed)
 
 RSpec.configure do |config|
   # Use documentation formatter when running a single file.


### PR DESCRIPTION
Build failures should now be reproducible by using the failing build's RSpec seed