### PR TITLE
most recent photos were not being selected for inclusion

### DIFF
--- a/lib/tasks/adoptapet_sync.rake
+++ b/lib/tasks/adoptapet_sync.rake
@@ -20,9 +20,7 @@ namespace :adoptapet_sync do
       puts Time.now.strftime("%m/%d/%Y %H:%M")+ " Adoptapet #{state} Export Start"
 
       dogs = Dog.joins(:foster).where(
-        { status: ["adoptable",
-          "adoption pending",
-          "coming soon"],
+        { status: Dog::PUBLIC_STATUSES,
           users: {region: state}
          })
 
@@ -31,8 +29,8 @@ namespace :adoptapet_sync do
       CSV.open(path + filename, "wt", force_quotes: "true", col_sep: ",") do |csv|
         dogs.each do |d|
           photo_urls = Array.new
-          d.photos.visible.order('updated_at desc')
-          d.photos.visible[0..3].each do |p|
+          pics = d.photos.visible.reorder('updated_at desc')
+          pics[0..3].each do |p|
             photo_urls << p.photo.url(:large)
           end
 

--- a/spec/factories/dog.rb
+++ b/spec/factories/dog.rb
@@ -23,6 +23,15 @@ FactoryBot.define do
     intake_dt { Date.today.advance(:days => -rand(365)) }
     primary_breed_id { Breed.pluck(:id).sample }
     secondary_breed_id { Breed.pluck(:id).sample }
+    is_uptodateonshots { [true, false].sample }
+    is_special_needs        { [true, false].sample }
+    no_dogs                 { [true, false].sample }
+    no_cats                 { [true, false].sample }
+    no_kids                 { [true, false].sample }
+    description { Faker::Lorem.paragraphs(3,true).join("\n\n") }
+    medical_summary { Faker::Lorem.paragraph }
+    behavior_summary { Faker::Lorem.paragraph }
+    craigslist_ad_url { [Faker::Internet.url, nil].sample }
 
     after(:create) do |dog|
       create(:comment, :commentable_type => 'Dog', :commentable_id => dog.id, :content => Faker::Lorem.sentence )

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -39,5 +39,9 @@ FactoryBot.define do
       password "foobar99"
       password_confirmation "foobar99"
     end
+
+    factory :foster do
+      is_foster true
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,4 +28,8 @@ RSpec.configure do |config|
   config.after(:suite) do
     FileUtils.rm_rf(Dir["#{Rails.root}/spec/test_files/"])
   end
+
+  config.define_derived_metadata(:file_path => Regexp.new('/spec/rake/')) do |metadata|
+    metadata[:type] = :model
+  end
 end

--- a/spec/support/tasks.rb
+++ b/spec/support/tasks.rb
@@ -1,0 +1,36 @@
+# thank you Elliot Sykes https://www.eliotsykes.com/test-rails-rake-tasks-with-rspec
+# For testing rake tasks
+require 'rake'
+
+# Task names should be used in the top-level describe, with an optional
+# "rake "-prefix for better documentation. Both of these will work:
+#
+# 1) describe 'foo:bar' do ... end
+#
+# 2) describe 'rake foo:bar' do ... end
+#
+# Favor including 'rake '-prefix as in the 2nd example above as it produces
+# doc output that makes it clear a rake task is under test and how it is
+# invoked.
+module TaskExampleGroup
+  extend ActiveSupport::Concern
+
+  included do
+    let(:task_name) { self.class.top_level_description.sub(/\Arake /, '') }
+    let(:tasks) { Rake::Task }
+    subject(:task) { tasks[task_name] }
+  end
+end
+
+
+RSpec.configure do |config|
+  config.define_derived_metadata(:file_path => %r{/spec/tasks/}) do |metadata|
+    metadata[:type] = :task
+  end
+
+  config.include TaskExampleGroup, type: :task
+
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
+end

--- a/spec/tasks/adoptapet_sync_spec.rb
+++ b/spec/tasks/adoptapet_sync_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+require_relative '../helpers/rspec_matchers'
+
+describe 'adoptapet_sync:export_upload', type: :task do
+  describe 'inclusion of photos in the csv' do
+    5.times do |i|
+      let("photo#{i}"){ FactoryBot.build(:photo, updated_at: DateTime.new(2018,1,i+1)) }
+    end
+    let(:foster) { FactoryBot.create(:foster, region: "VA") }
+    let!(:dog) { FactoryBot.create(:dog, status: 'adoptable', foster_id: foster.id, photos_attributes: [photo0,photo1,photo2,photo3,photo4].map(&:attributes)) }
+    let!(:rake){ task.execute }
+    let(:recent_photos){ Dog.first.photos.sort_by{|photo| photo.updated_at}.reverse[0..3]}
+    let(:photo_urls){ recent_photos.map{|photo| photo.photo.url(:large)} }
+    let(:csv) { CSV.read( '/tmp/adoptapet/pets_VA.csv' ) }
+
+    it "should include most recent four photos for a dog" do
+      csv_photos = csv.first[16..19]
+      # just confirming recent_photos are the ones we want to upload
+      # expect most recent first
+      expect(recent_photos.map(&:updated_at)).to be_sorted(:descending)
+      expect(csv_photos).to eq photo_urls
+    end
+  end
+
+  describe 'inclusion of dogs by status' do
+    let(:foster) { FactoryBot.create(:foster, region: "VA") }
+    Dog::STATUSES.each do |status|
+      dog_type = status.gsub(/\s/,'_')+'_dog'
+      let!(dog_type){ FactoryBot.create(:dog, status: status, foster_id: foster.id) }
+    end
+
+    let!(:rake){ task.execute }
+    let(:csv) { CSV.read( '/tmp/adoptapet/pets_VA.csv' ) }
+
+    it 'should include only adoptable, adoption pending and coming soon dogs' do
+      included_ids = csv.map{|row| row[0]}
+      expect(csv.map{|row| row[0]}).to match_array [adoptable_dog.id, adoption_pending_dog.id, coming_soon_dog.id].map(&:to_s)
+    end
+  end
+
+  describe 'inclusion of dogs by location of foster' do
+    let(:va_foster) { FactoryBot.create(:foster, region: "VA") }
+    let(:ca_foster) { FactoryBot.create(:foster, region: "CA") }
+    let!(:va_dog){ FactoryBot.create(:dog, status: 'adoptable', foster_id: va_foster.id) }
+    let!(:ca_dog){ FactoryBot.create(:dog, status: 'adoptable', foster_id: ca_foster.id) }
+
+    let!(:rake){ task.execute }
+    let(:csv) { CSV.read( '/tmp/adoptapet/pets_VA.csv' ) }
+
+    it 'should include only adoptable, adoption pending and coming soon dogs' do
+      included_ids = csv.map{|row| row[0]}
+      expect(csv.map{|row| row[0]}).to match_array [va_dog.id].map(&:to_s)
+    end
+  end
+end


### PR DESCRIPTION
I noticed what appeared to be a bug in the rake task for adoptapet sync. The intention _appears_ to be that the urls of the four most recent photos should be included in the uploaded csv.

However, by inspection of the code, this was not happening, and  a test (see spec/tasks/adoptapet_sync_spec.rb) confirmed that it was not.