### PR TITLE
Excel download of User Data

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -89,7 +89,11 @@ class UsersController < ApplicationController
     @users = UserSearcher.search(params: params)
     respond_to do |format|
       format.html
-      format.xls { render_users_xls }
+      if current_user.admin?
+        format.xls { render_users_xls }
+      else
+        format.xls { head :forbidden }
+      end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -87,6 +87,10 @@ class UsersController < ApplicationController
     @options = YES_NO_OPTIONS
     @rent_options = OWN_RENT_OPTIONS
     @users = UserSearcher.search(params: params)
+    respond_to do |format|
+      format.html
+      format.xls { render_users_xls }
+    end
   end
 
   def show
@@ -271,5 +275,31 @@ class UsersController < ApplicationController
 
   def admin_user
     redirect_to(root_path) unless current_user.admin?
+  end
+
+  def render_users_xls
+    send_data @users.to_xls(
+      filename: 'users.xls',
+      columns: [
+        :id,
+        :name,
+        :email,
+        :phone,
+        :address1,
+        :address2,
+        :city,
+        :region
+      ],
+      headers: [
+        'id',
+        'Name',
+        'Email',
+        'Phone',
+        'Address 1',
+        'Address 2',
+        'City',
+        'State'
+      ]
+    )
   end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -80,6 +80,12 @@
   </li>
 </ul>
 
+<% if is_admin? %>
+  <p>
+  <%= link_to "Download to Excel", users_path(format: :xls, params: request.query_parameters) , :class => "btn btn-success" %>
+  </p>
+<% end %>
+
 <% if params[:foster] == 'true' %>
   <div class="container-fluid">
     <div class="row-fluid">

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -130,6 +130,27 @@ describe UsersController, type: :controller do
         get :index, params: { active_volunteer: true }
         expect(assigns(:users)).to match_array([smith, admin, active_user])
       end
+
+      it 'returns excel list of users' do
+        get :index, format: :xls
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'logged in as an active user' do
+      before :each do
+        allow(controller).to receive(:current_user) { active_user }
+      end
+
+      it 'can view users index' do
+        get :index
+        expect(assigns(:users)).to match_array([jones, admin, active_user, inactive_user])
+      end
+
+      it 'cannot view excel xls export' do
+        get :index, format: :xls
+        expect(response).to have_http_status(403)
+      end
     end
 
     context 'logged in as an inactive user' do
@@ -138,7 +159,7 @@ describe UsersController, type: :controller do
       end
 
       it 'cannot view users index' do
-        get(:index)
+        get :index
         expect(inactive_user).to redirect_to('/')
       end
     end


### PR DESCRIPTION
Simple excel dump of user data to help management do cleanup of user accounts.  

Ideally the xls format would be blocked unless someone had admin permissions, instead of just a button hide.   So far my attempts at getting that to work in a `:before_action` have been futile.  I think that restriction is more of a nice to have than a must have.  

Regardless, if anyone has some suggestions, lmk.  Thanks!