### PR TITLE
Roll back ie ES5 syntax to Fix ie11 problems

### DIFF
--- a/app/assets/javascripts/dogs_index.js
+++ b/app/assets/javascripts/dogs_index.js
@@ -62,11 +62,11 @@ GlobalMultiSelect.filter_select = function(event){
   }
 };
 
-GlobalMultiSelect.selection_callback = function($li){
+GlobalMultiSelect.selection_callback = function ($li) {
   var $text_input = $li.closest('ul.dropdown-menu').find('.input-group input.form-control');
-  var text = $li.text().trim()
-  $text_input.attr('placeholder',`${text} (all/part)`);
-  $text_input.focus()
+  var text = $li.text().trim();
+  $text_input.attr('placeholder', text + ' (all/part)');
+  $text_input.focus();
 };
 
 GlobalMultiSelect.manage_search_button_visibility = function(){
@@ -76,8 +76,8 @@ GlobalMultiSelect.manage_search_button_visibility = function(){
     { $search_button.hide()}else{ $search_button.show()};
 };
 
-GlobalMultiSelect.add_error=function($field,text){
-  $field.after(`<div class='text-input-error'>${text}</div>`)
+GlobalMultiSelect.add_error = function ($field, text) {
+  $field.after("<div class='text-input-error'>" + text + "</div>");
 };
 
 $(function(){

--- a/app/views/dogs/manager/_dog_form.html.erb
+++ b/app/views/dogs/manager/_dog_form.html.erb
@@ -291,29 +291,33 @@
 
 <script type='text/javascript'>
 // add/remove new photo or document inputs
-  var new_attachment_input = _.template($('#new_attachment_input').html())
-  var last_photos_index, last_attachments_index
-  ["photos", "attachments"].forEach(function(type){
-    var singular_type = type.replace(/s$/,'');
-    var indexes = $.map($(`#manage_${type} .${singular_type}`), function(el){ return $(el).data('index')}) 
-    if(_.isEmpty(indexes)){
-      this[`last_${type}_index`] = -1
-    }else{
-      this[`last_${type}_index`] = _.max(indexes)
+  var new_attachment_input = _.template($('#new_attachment_input').html());
+  var last_photos_index, last_attachments_index;
+  ["photos", "attachments"].forEach(function (type) {
+    var singular_type = type.replace(/s$/, '');
+    var indexes = $.map($("#manage_" + type + " ." + singular_type), function (el) {
+      return $(el).data('index');
+    });
+    if (_.isEmpty(indexes)) {
+      this["last_" + type + "_index"] = -1;
+    } else {
+      this["last_" + type + "_index"] = _.max(indexes);
     }
-  })
-  var add_file_field_for = function(type){
-    var unconfigured_inputs_count = _.filter($(`.new_${type} input`),function(input){return _.isEmpty(input.value)}).length;
+  });
+  var add_file_field_for = function add_file_field_for(type) {
+    var unconfigured_inputs_count = _.filter($(".new_" + type + " input"), function (input) {
+      return _.isEmpty(input.value);
+    }).length;
     var all_inputs_configured = unconfigured_inputs_count == 0;
-    var file_inputs_count = $(`.new_${type} input`).length;
+    var file_inputs_count = $(".new_" + type + " input").length;
     var no_inputs_displayed = file_inputs_count == 0;
     var inputs_displayed = !no_inputs_displayed;
-    var singular_type = type.replace(/s$/,'');
-    if(no_inputs_displayed || (inputs_displayed && all_inputs_configured)){
-      var new_input = new_attachment_input({type: type, singular_type: singular_type, index: ++this[`last_${type}_index`]})
-      $(new_input).appendTo($(`.new_${type}`)).animate({height: '28px'}, 100);
+    var singular_type = type.replace(/s$/, '');
+    if (no_inputs_displayed || inputs_displayed && all_inputs_configured) {
+      var new_input = new_attachment_input({ type: type, singular_type: singular_type, index: ++this["last_" + type + "_index"] });
+      $(new_input).appendTo($(".new_" + type)).animate({ height: '28px' }, 100);
     }
-  }
+  };
 
   $(function(){
     $('#add_photo').on('click', function(event){
@@ -355,4 +359,3 @@
     })
   })
 </script>
-


### PR DESCRIPTION
Our dear friend IE11 doesn't like ES6 syntax.    And we have some users that are stuck with ie11 due to the usual corporate stuff. 

This fixes the IE11 issues #856 #855 #854 