### PR TITLE
fixes ie11 form validation errors

### DIFF
--- a/app/assets/javascripts/html5_bootstrap_form_validation.js
+++ b/app/assets/javascripts/html5_bootstrap_form_validation.js
@@ -1,22 +1,25 @@
 $(function(){
   var check_form_validity = function(){
-    if ($('form.was-validated').is(':invalid')) {
+    if ($('form.was-validated :input:invalid').length > 0) {
       $('.actions').addClass('form-errors')
     }else{
       $('.actions').removeClass('form-errors')
     }
   }
 
-  $('form :input').on({change: check_form_validity, keyup: check_form_validity })
 
   var $form = $('form.needs-validation');
-  $form.on('submit', function(event){
+
+  var validate_form_fields = function(event){
     if ($form[0].checkValidity() === false) {
       event.preventDefault(); // prevents form submission
       event.stopPropagation();
     }
     $form.addClass('was-validated');
     check_form_validity();
-  });
+  }
+
+  $('form :input').on({change: validate_form_fields, keyup: validate_form_fields })
+  $form.on('submit', validate_form_fields);
 });
 


### PR DESCRIPTION
IE11 was exhibiting "flakey" behaviour in the HTML5 form validation process.

The existence and the fix are verified manually, as it is not yet possible to run the test suite on IE. In fact the bug surfaced whilst debugging running the test suite on IE.

Because this is a defect, it should be committed and deployed ahead of the availability of the test suite running on IE.