### PR TITLE
Firefox non headless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rake db:test:prepare
   - bundle exec rspec spec/
-  - BROWSER=firefox bundle exec rspec spec/
+  - BROWSER=firefox_headless bundle exec rspec spec/
 
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz

--- a/README.md
+++ b/README.md
@@ -70,7 +70,19 @@ brew install geckodriver
 and then run tests with:
 
 ```
-BROWSER=firefox rspec spec # environment variable switch in rails_helper.rb
+BROWSER=firefox_headless rspec spec # environment variable switch in rails_helper.rb
+```
+
+To facilitate debugging, you can run Firefox in the non-headless mode with:
+
+```
+BROWSER=firefox rspec spec
+```
+
+A rake task is included to test agains multiple browsers:
+
+```
+rake rescue_rails:test_suite
 ```
 
 ### File Attachment Storage

--- a/lib/tasks/test_suite.rake
+++ b/lib/tasks/test_suite.rake
@@ -1,0 +1,6 @@
+namespace :rescue_rails do
+  task :test_suite do
+    system 'rspec spec/'
+    system 'BROWSER=firefox_headless rspec spec/features'
+  end
+end

--- a/spec/drivers/selenium_chrome_headless.rb
+++ b/spec/drivers/selenium_chrome_headless.rb
@@ -1,0 +1,7 @@
+Capybara.register_driver :selenium_chrome_headless do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[headless disable-gpu window-size=1366,2000] }
+  )
+  Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
+end
+

--- a/spec/drivers/selenium_firefox.rb
+++ b/spec/drivers/selenium_firefox.rb
@@ -1,0 +1,8 @@
+Capybara.register_driver :selenium_firefox do |app|
+  options = Selenium::WebDriver::Firefox::Options.new
+  Capybara::Selenium::Driver.new(app, :browser => :firefox, :options => options)
+end
+
+Capybara::Screenshot.register_driver(:selenium_firefox) do |driver, path|
+  driver.browser.save_screenshot(path)
+end

--- a/spec/drivers/selenium_firefox_headless.rb
+++ b/spec/drivers/selenium_firefox_headless.rb
@@ -1,0 +1,9 @@
+Capybara.register_driver :selenium_firefox_headless do |app|
+  options = Selenium::WebDriver::Firefox::Options.new
+  options.add_argument('-headless')
+  Capybara::Selenium::Driver.new(app, :browser => :firefox, :options => options)
+end
+
+Capybara::Screenshot.register_driver(:selenium_firefox_headless) do |driver, path|
+  driver.browser.save_screenshot(path)
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,28 +10,17 @@ require 'capybara/rails'
 require 'capybara-screenshot/rspec'
 
 require 'selenium/webdriver'
+require 'drivers/selenium_chrome_headless'
+require 'drivers/selenium_firefox_headless'
+require 'drivers/selenium_firefox'
 
-# Headless Chrome
-Capybara.register_driver :selenium_chrome_headless do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu window-size=1366,2000] }
-  )
-  Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
-end
 
-Capybara.register_driver :selenium_firefox_headless do |app|
-  options = Selenium::WebDriver::Firefox::Options.new
-  options.add_argument('-headless')
-  Capybara::Selenium::Driver.new(app, :browser => :firefox, :options => options)
-end
-
-Capybara::Screenshot.register_driver(:selenium_firefox_headless) do |driver, path|
-  driver.browser.save_screenshot(path)
-end
-
-if ENV['BROWSER'] == 'firefox'
+if ENV['BROWSER'] == 'firefox_headless'
   puts 'testing with firefox headless'
   Capybara.javascript_driver = :selenium_firefox_headless
+elsif ENV['BROWSER'] == 'firefox'
+  puts 'testing with firefox'
+  Capybara.javascript_driver = :selenium_firefox
 else
   puts 'testing with chrome headless'
   Capybara.javascript_driver = :selenium_chrome_headless


### PR DESCRIPTION
Add driver and environment variable switch to run Firefox in non-headless mode, to facilitate debugging of Firefox-specific test failures.

Invoke Firefox headless with:
```
BROWSER=firefox_headless rspec spec
```
Invoke Firefox non-headless with:
```
BROWSER=firefox rspec spec
```
Run entire suite with both Chrome headless and Firefox headless with (as we do on TravisCi):
```
rake rescue_rails:test_suite
```