### PR TITLE
fixes Event validation error

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -51,7 +51,7 @@ class Event < ApplicationRecord
                         :address,
                         :description
 
-  validates_format_of :location_url, with: URI::regexp(%w[http https])
+  validates_format_of :location_url, with: URI::regexp(%w[http https]), allow_blank: true
 
   validates :title, length: { maximum: 255 }
   validates :location_name, length: { maximum: 255 }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -29,11 +29,11 @@
 require 'rails_helper'
 
 describe Event do
-  let(:event) { build(:event) }
+  it 'has a valid factory' do
+    expect(build(:event)).to be_valid
+  end
 
-  context 'has a valid factory' do
-    it 'is valid' do
-      expect(build(:event)).to be_valid
-    end
+  it 'is valid when location_url is blank' do
+    expect(build(:event, location_url: nil)).to be_valid
   end
 end


### PR DESCRIPTION
was failing to validate when location_url was blank, apparently this was not the intended behaviour