### PR TITLE
Limit Travis Firefox build to only feature branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ env:
     - secure: "CJKFy918mjHbn7oDpuhbhiVR1d2qT4ktu/mABcrLAdT31pcPO9RKExNw/fp3P3gkfcLB/kQhWQfdrknqlHWiQiJj2z2HlaJJLQDNelpKsKPOHRo0GAq0N/aBwEu6wDk+GQb2PjxeYHFaQ0uupzNiqAup6glWokCpPuUUV2eb6js="
     - secure: "AnnnXIFPy93JvGO+DuqSpYGPd9MZNSxwciYKTcCV6Yx5htJwZFU6adAak9UWvXr8vjtfwrHJD/VqViC6GII7toVCF9O9XEc6ooHVHsLGxfqvl0uOy+prgZS0F8bYW8n6EjFrWPfywdEoMn8PsZ/9iNxPFC2tH8vVKmJAq/FnxUo="
   matrix:
-    - BROWSER=chrome_headless
-    - BROWSER=firefox_headless
+    - RSPEC_CMD='BROWSER=chrome_headless bundle exec rspec spec/'
+    - RSPEC_CMD='BROWSER=firefox_headless bundle exec rspec spec/features/'
 
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rake db:test:prepare
-  - BROWSER=$BROWSER bundle exec rspec spec/
+  - $RSPEC_CMD
 
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
     - secure: "CJKFy918mjHbn7oDpuhbhiVR1d2qT4ktu/mABcrLAdT31pcPO9RKExNw/fp3P3gkfcLB/kQhWQfdrknqlHWiQiJj2z2HlaJJLQDNelpKsKPOHRo0GAq0N/aBwEu6wDk+GQb2PjxeYHFaQ0uupzNiqAup6glWokCpPuUUV2eb6js="
     - secure: "AnnnXIFPy93JvGO+DuqSpYGPd9MZNSxwciYKTcCV6Yx5htJwZFU6adAak9UWvXr8vjtfwrHJD/VqViC6GII7toVCF9O9XEc6ooHVHsLGxfqvl0uOy+prgZS0F8bYW8n6EjFrWPfywdEoMn8PsZ/9iNxPFC2tH8vVKmJAq/FnxUo="
   matrix:
-    - RSPEC_CMD='BROWSER=chrome_headless bundle exec rspec spec/'
-    - RSPEC_CMD='BROWSER=firefox_headless bundle exec rspec spec/features/'
+    - RSPEC_CMD="BROWSER=chrome_headless bundle exec rspec spec/"
+    - RSPEC_CMD="BROWSER=firefox_headless bundle exec rspec spec/features/"
 
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ env:
     - secure: "CJKFy918mjHbn7oDpuhbhiVR1d2qT4ktu/mABcrLAdT31pcPO9RKExNw/fp3P3gkfcLB/kQhWQfdrknqlHWiQiJj2z2HlaJJLQDNelpKsKPOHRo0GAq0N/aBwEu6wDk+GQb2PjxeYHFaQ0uupzNiqAup6glWokCpPuUUV2eb6js="
     - secure: "AnnnXIFPy93JvGO+DuqSpYGPd9MZNSxwciYKTcCV6Yx5htJwZFU6adAak9UWvXr8vjtfwrHJD/VqViC6GII7toVCF9O9XEc6ooHVHsLGxfqvl0uOy+prgZS0F8bYW8n6EjFrWPfywdEoMn8PsZ/9iNxPFC2tH8vVKmJAq/FnxUo="
   matrix:
-    - RSPEC_CMD="'BROWSER=chrome_headless bundle exec rspec spec/'"
-    - RSPEC_CMD="'BROWSER=firefox_headless bundle exec rspec spec/features/'"
+    - BROWSER=chrome_headless SUITE=spec/
+    - BROWSER=firefox_headless SUITE=spec/features
 
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rake db:test:prepare
-  - $RSPEC_CMD
+  - BROWSER=$BROWSER bundle exec rspec $SUITE
 
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
     - secure: "CJKFy918mjHbn7oDpuhbhiVR1d2qT4ktu/mABcrLAdT31pcPO9RKExNw/fp3P3gkfcLB/kQhWQfdrknqlHWiQiJj2z2HlaJJLQDNelpKsKPOHRo0GAq0N/aBwEu6wDk+GQb2PjxeYHFaQ0uupzNiqAup6glWokCpPuUUV2eb6js="
     - secure: "AnnnXIFPy93JvGO+DuqSpYGPd9MZNSxwciYKTcCV6Yx5htJwZFU6adAak9UWvXr8vjtfwrHJD/VqViC6GII7toVCF9O9XEc6ooHVHsLGxfqvl0uOy+prgZS0F8bYW8n6EjFrWPfywdEoMn8PsZ/9iNxPFC2tH8vVKmJAq/FnxUo="
   matrix:
-    - RSPEC_CMD="BROWSER=chrome_headless bundle exec rspec spec/"
-    - RSPEC_CMD="BROWSER=firefox_headless bundle exec rspec spec/features/"
+    - RSPEC_CMD="'BROWSER=chrome_headless bundle exec rspec spec/'"
+    - RSPEC_CMD="'BROWSER=firefox_headless bundle exec rspec spec/features/'"
 
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace


### PR DESCRIPTION
This limits the firefix_headless build job to only run the feature tests.  Sadly didn't make too much of a different in test builds so far, but still a good idea!

Thanks @lazylester 