### PR TITLE
fixes #887 Reset Filter Sort no longer appearing on Dog Manager Index

### DIFF
--- a/app/helpers/dogs_helper.rb
+++ b/app/helpers/dogs_helper.rb
@@ -37,6 +37,10 @@ module DogsHelper
     @filter_params && @filter_params["has_flags"] && !@filter_params["has_flags"].empty?
   end
 
+  def filter_active?
+    [age_filter_active?, status_filter_active?, size_filter_active?, flag_filter_active?].any?
+  end
+
   def selected_flags
     @filter_params && @filter_params["has_flags"] && (Dog::FILTER_FLAGS.as_options.slice(*@filter_params["has_flags"])).values
   end
@@ -89,7 +93,7 @@ module DogsHelper
   end
 
   def default_search_sort?
-    !search_active? && !sort_active?
+    !search_active? && !sort_active? && !filter_active?
   end
 
   def sort_active?

--- a/spec/features/dog_filter_spec.rb
+++ b/spec/features/dog_filter_spec.rb
@@ -166,6 +166,7 @@ feature 'Filter Dogs List', js: true do
           expect(page).to have_selector(filter_params, text: "Tracking ID")
           expect(page).to have_selector(group_label, text: "Flags:")
           expect(page).to have_selector(filter_params, text: text)
+          expect(page).to have_selector('#reset_message')
           expect(dog_names).to eq [text]
           expect(dog_names.count).to eq 1
         end
@@ -195,6 +196,7 @@ feature 'Filter Dogs List', js: true do
         expect(page).to have_selector(filter_params, text: "Tracking ID")
         expect(page).to have_selector(group_label, text: "Size:")
         expect(page).to have_selector(filter_params, text: text )
+        expect(page).to have_selector('#reset_message')
         expect(dog_names).to eq ["#{text.titleize} Dog"]
         expect(dog_names.count).to eq 1
       end
@@ -230,6 +232,7 @@ feature 'Filter Dogs List', js: true do
         expect(page).to have_selector(filter_params, text: "Tracking ID")
         expect(page).to have_selector(group_label, text: "Status:")
         expect(page).to have_selector(filter_params, text: text )
+        expect(page).to have_selector('#reset_message')
         expect(dog_names).to eq ["#{text.titleize} Dog"]
         expect(dog_names.count).to eq 1
       end
@@ -259,6 +262,7 @@ feature 'Filter Dogs List', js: true do
         expect(page).to have_selector(filter_params, text: "Tracking ID")
         expect(page).to have_selector(group_label, text: "Age:")
         expect(page).to have_selector(filter_params, text: text )
+        expect(page).to have_selector('#reset_message')
         expect(dog_names).to eq ["#{text.titleize} Dog"]
         expect(dog_names.count).to eq 1
       end


### PR DESCRIPTION
fixes #887 