### PR TITLE
fix html errors reported by IE11

### DIFF
--- a/app/views/audited/audits/_audit.html.erb
+++ b/app/views/audited/audits/_audit.html.erb
@@ -18,7 +18,9 @@
       <% if audit.action == 'update' %>
         <table class="table table-bordered table-striped change-audit-item">
           <thead>
-            <th>Field</th><th>Old Value</th><th>New Value</th>
+            <tr>
+              <th>Field</th><th>Old Value</th><th>New Value</th>
+            </tr>
           </thead>
           <tbody>
             <% audit.audited_changes.each do |key, value| %>

--- a/app/views/dogs/manager/show.html.erb
+++ b/app/views/dogs/manager/show.html.erb
@@ -112,7 +112,7 @@
         <dt>Ads</dt>
         <dd>
           <div id='adoptapet_ad'><%= @adoptapet %></div>
-          <div><a href=<%= PETFINDER::OPH_PAGE %>>Petfinder</a></div>
+          <div><a href="<%= PETFINDER::OPH_PAGE %>">Petfinder</a></div>
           <div id='craigslist_ad_url'>
             <%= link_to_if @dog.craigslist_ad_url, "Craigslist", @dog.craigslist_ad_url do "Needs Craigslist ad" end %>
           </div>


### PR DESCRIPTION
errors don't seem to affect the rendering, but IE11 (correctly) reports the errors not reported by other browsers