### PR TITLE
remove .sprockets_manifest after tests finished

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,7 @@ RSpec.configure do |config|
     FileUtils.rm_rf(Dir["#{Rails.root}/spec/test_files/"])
     FileUtils.rm_rf(Dir[Rails.root.join('public', 'system', 'test')])
     FileUtils.rm_rf(Dir[Rails.root.join('public', 'assets', '*')])
+    FileUtils.rm(Dir[Rails.root.join('public', 'assets', '.sprockets*')])
   end
 
   config.define_derived_metadata(:file_path => Regexp.new('/spec/rake/')) do |metadata|


### PR DESCRIPTION
fixes a problem when running tests on local machine (not travis), cleanup of precompiled assets removed the assets but not the manifest file.