### PR TITLE
fixes #900, context menu not available on mobile devices

### DIFF
--- a/app/views/dogs/gallery/show.html.erb
+++ b/app/views/dogs/gallery/show.html.erb
@@ -83,7 +83,8 @@
     responsive: true,
     imageCrop: false,
     dataSource: <%= @carousel %>,
-    theme: 'classic'
+    theme: 'classic',
+    swipe: false
   });
 
   $(function () {

--- a/app/views/dogs/manager/show.html.erb
+++ b/app/views/dogs/manager/show.html.erb
@@ -149,6 +149,8 @@
   $('#galleria').galleria({
     responsive: true,
     imageCrop: false,
-    dataSource: <%= @carousel %>
+    dataSource: <%= @carousel %>,
+    theme: 'classic',
+    swipe: false
   });
 </script>


### PR DESCRIPTION
upgrade to galleria v 1.5.7 was necessary to eliminate errors that were apparently related to the bootstrap upgrade

however galleria v 1.5.7 "swipe" feature causes failure of the context menu triggered by mobile device "long press".

In this PR. the galleria "swipe" feature has been disabled via its options config. So we are choosing to have the context menu and forego the swipe feature.

Someone who has much better js chops than me could probably figure out the reason why galleria's swipe feature borks the context menu. 

I have submitted an issue to [galleria github repo](https://github.com/worseisbetter/galleria/issues/403#issue-353964208) But there does not seem to be much activity resolving issues over there.