### PR TITLE
Removes unused roo gem which has security issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'rails4-autocomplete'
 gem 'record_tag_helper', '~> 1.0'
 gem 'redcarpet'
 gem 'responders'
-gem 'roo', '~>1.13.2'
 gem 'strip_attributes'
 gem 'to_xls'
 gem 'whenever', '~> 0.9.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,10 +301,6 @@ GEM
       railties (>= 4.2.0, < 5.3)
     rollbar (2.15.5)
       multi_json
-    roo (1.13.2)
-      nokogiri
-      rubyzip
-      spreadsheet (> 0.6.4)
     rspec-collection_matchers (1.1.3)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.8.0)
@@ -466,7 +462,6 @@ DEPENDENCIES
   redcarpet
   responders
   rollbar (= 2.15.5)
-  roo (~> 1.13.2)
   rspec-collection_matchers
   rspec-rails
   rubocop


### PR DESCRIPTION
It looks like this is used in commented out code in the banned adopters controller.

@markottaviani do we still do banned adopter importing from spreadsheets?