### PR TITLE
remove acts_as_list unused gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'rails', '~> 5.2.1'
 
 gem 'rack-cache'
 
-gem 'acts_as_list'
 gem 'audited', '~> 4.5'
 gem 'aws-sdk', '~> 2'
 gem 'bootstrap', '~> 4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,8 +42,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts_as_list (0.9.16)
-      activerecord (>= 3.0)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     annotate (2.7.4)
@@ -405,7 +403,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acts_as_list
   annotate
   audited (~> 4.5)
   aws-sdk (~> 2)

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -31,7 +31,6 @@
 class Photo < ApplicationRecord
   extend ActionView::Helpers::AssetUrlHelper
   belongs_to :dog, touch: true
-  acts_as_list scope: :dog
 
   HASH_SECRET = "80fd0acd1674d7efdda5b913a7110d5c955e2d73"
   PAPERCLIP_STORAGE_PATH = { test:       "/system/test/photos/:hash.:extension",


### PR DESCRIPTION
Included only in the photo model, but apparently no longer used as the position attribute is managed by our own code.