### PR TITLE
on edit cancel, return to dog profile

### DIFF
--- a/app/controllers/dogs/manager_controller.rb
+++ b/app/controllers/dogs/manager_controller.rb
@@ -89,11 +89,13 @@ class Dogs::ManagerController < Dogs::DogsBaseController
 
   def new
     @dog = Dog.new
+    @on_cancel_path = dogs_manager_index_path
     load_instance_variables
   end
 
   def edit
     load_instance_variables
+    @on_cancel_path = dogs_manager_path(@dog)
   end
 
   def update

--- a/app/views/dogs/manager/_dog_form.html.erb
+++ b/app/views/dogs/manager/_dog_form.html.erb
@@ -277,7 +277,7 @@
     <%= f.text_area :behavior_summary, class: "input-xxlarge form-control form-control-sm", rows: "8", disabled: !can_manage_medical_behavior_summaries? %>
   </div>
 
-  <%= submit_or_return_to(f, dogs_manager_index_path) %>
+  <%= submit_or_return_to(f, @on_cancel_path) %>
 
 <% end %>
 

--- a/spec/features/add_dog_spec.rb
+++ b/spec/features/add_dog_spec.rb
@@ -182,6 +182,13 @@ feature 'add a dog', js: true do
       end
     end
 
+    describe 'cancel while adding' do
+      it "should return to the dog manager page" do
+        click_link('Cancel')
+        expect(page_heading).to eq 'Dog Manager'
+      end
+    end
+
     context 'user enters invalid attributes --client-side validation' do
       context 'no status selected' do
         it "should not save and should notify user" do
@@ -295,7 +302,6 @@ feature 'add a dog', js: true do
           expect( Dog.first.fee ).to eq 88
         end
       end
-
     end
 
     #uniqueness of name validated on server
@@ -315,7 +321,6 @@ feature 'add a dog', js: true do
           expect(flash_error_message).to eq "form could not be saved, see errors below"
         end
       end
-
     end
   end
 end

--- a/spec/features/dogs_manager_index_spec.rb
+++ b/spec/features/dogs_manager_index_spec.rb
@@ -32,27 +32,3 @@ feature 'add a new dog', js: true do
     expect(dog_names).to include "Fido"
   end
 end
-
-feature 'edit a dog', js: true do
-  include ApplicationHelpers
-
-  let!(:active_user) { create(:user, :admin) }
-  let!(:dog) { create(:dog) }
-
-  before do
-    sign_in(active_user)
-    visit edit_dogs_manager_path(dog)
-    expect(page_heading).to eq "Edit Dog"
-  end
-
-  it 'should cancel back to the manager list' do
-    click_link "Cancel"
-    expect(page_heading).to eq "Dog Manager"
-  end
-
-  it "update dog attributes" do
-    fill_in('Name', with: 'Rover')
-    click_button "Submit"
-    expect(page_heading).to match  /Rover/
-  end
-end

--- a/spec/features/edit_dog_spec.rb
+++ b/spec/features/edit_dog_spec.rb
@@ -278,6 +278,14 @@ feature 'edit a dog', js: true do
       end
     end
 
+    describe 'cancel while editing' do
+      it "should return to the dog profile" do
+        click_link('Cancel')
+        dog = Dog.first
+        expect(page_heading).to eq "##{dog.tracking_id} #{dog.name}"
+      end
+    end
+
     context 'user enters invalid attributes --client-side validation' do
       context 'non-integer tracking id' do
         it "should not save, and should notify user" do


### PR DESCRIPTION
when editing a dog and cancelling, it was returning to the index page, but should more appropriately return to the dog manager profile page, where the user was prior to editing