### PR TITLE
Adds remember me checkbox to sign in

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -19,7 +19,7 @@
 
       <div class="remember-me-field mb-20">
         <label class="checkbox">
-          <%= form.check_box :remember_me %> Remember Me
+          <input type="checkbox" name="remember_me"> Remember Me
         </label>
       </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -17,6 +17,12 @@
         <%= form.password_field :password %>
       </div>
 
+      <div class="remember-me-field mb-20">
+        <label class="checkbox">
+          <%= form.check_box :remember_me %> Remember Me
+        </label>
+      </div>
+
       <div class="submit-field">
         <%= form.submit %>
       </div>

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -8,5 +8,5 @@ Clearance.configure do |config|
   config.routes = false
   config.sign_in_guards = []
 
-  config.cookie_expiration = ->(cookies) { 1.year.from_now if cookies['remember_me'] }
+  config.cookie_expiration = ->(cookies) { 1.week.from_now if cookies['remember_me'] }
 end


### PR DESCRIPTION
The session expires when the browser is closed with no way to "remember me". I'm pretty sure this was in the code at some point but probably got lost in the rebasing mess.

This also makes the sessions last 1 week vs. 1 year.