### PR TITLE
Adds column last_login_at to user table

### DIFF
--- a/db/migrate/20180908004040_add_column_user_last_login_at.rb
+++ b/db/migrate/20180908004040_add_column_user_last_login_at.rb
@@ -1,0 +1,5 @@
+class AddColumnUserLastLoginAt < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :last_login_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_06_150422) do
+ActiveRecord::Schema.define(version: 2018_09_08_004040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -389,6 +389,7 @@ ActiveRecord::Schema.define(version: 2018_06_06_150422) do
     t.boolean "active", default: false, null: false, comment: "if false user is a candiate volunteer and should only be able to see and edit their profile"
     t.string "confirmation_token", limit: 128
     t.string "remember_token", limit: 128
+    t.datetime "last_login_at"
     t.index ["agreement_id"], name: "index_users_on_agreement_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["latitude", "longitude"], name: "index_users_on_latitude_and_longitude"


### PR DESCRIPTION
There is currently lastlogin on the User table but I see nothing that has ever populated this column. To safely migrate away from that we'll create a new column in this PR and then use the column in the next PR.