### PR TITLE
Event page Fix mobile view and Google Maps Links

### DIFF
--- a/app/models/google_map.rb
+++ b/app/models/google_map.rb
@@ -11,7 +11,7 @@ class GoogleMap
   def to_s
     template = <<-TMPL.html_safe
       <a href=#{link_url} target="_blank">
-        View on Google Maps
+        View Location on Google Maps
       </a>
     TMPL
   end

--- a/app/models/google_map.rb
+++ b/app/models/google_map.rb
@@ -2,7 +2,6 @@ class GoogleMap
   include Rails.application.routes.url_helpers
   attr_accessor :latitude, :longitude
   BASE_URL = "https://maps.google.com/"
-  IMG_PATH = "maps/api/staticmap?size=250x100&zoom=12&sensor=false&zoom=16&markers="
 
   def initialize(event)
     @latitude = event.latitude
@@ -11,16 +10,10 @@ class GoogleMap
 
   def to_s
     template = <<-TMPL.html_safe
-      <a href=#{link_url} class='google_map_link'>
-        <img src=#{img_src} />
+      <a href=#{link_url} target="_blank">
+        View on Google Maps
       </a>
     TMPL
-  end
-
-  def img_src
-    Rails.env.development? ?
-      sample_image_path(:map)+"?#{rand(1000000)}":
-      "#{BASE_URL}#{IMG_PATH}#{latitude}%2C#{longitude}"
   end
 
   def link_url

--- a/app/models/google_map.rb
+++ b/app/models/google_map.rb
@@ -10,7 +10,7 @@ class GoogleMap
 
   def to_s
     template = <<-TMPL.html_safe
-      <a href=#{link_url} target="_blank">
+      <a href=#{link_url} class='google_map_link' target="_blank">
         View Location on Google Maps
       </a>
     TMPL

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -18,11 +18,12 @@
         <div class='phone'> <%= event.location_phone %> </div>
       </address>
     <%= event.google_map %>
-    <div class='row <%= photographer?(event) %>'>
-      <div class='photographer col-12'><span>Event Photographer:</span> <%= link_to_if event.photographer_url?, event.photographer_name, event.photographer_url %></div>
+    <div class='<%= photographer?(event) %>'>
+      <div class='photographer'><span>Event Photographer:</span> <%= link_to_if event.photographer_url?, event.photographer_name, event.photographer_url %></div>
     </div>
-
-    <%= markdown(event.description) %>
+    <div class='description'>
+      <%= markdown(event.description) %>
+    </div>
 
     <div class='row'>
       <div class='col'>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,33 +1,28 @@
 <div class="row event-title">
-  <div class="col-md-8 offset-md-4">
+  <div class="colmd-8 offset-md-4">
     <h3><%= event.title %></h3>
     <div class='date_time'><%= event.event_date.strftime("%A, %B %-e, %Y") %> from <%= event.start_time.strftime("%-l:%M %P") %> to <%= event.end_time.strftime("%-l:%M %P") %></div>
   </div>
 </div>
 
 <div class="row event-body">
-  <div class="col-4">
+  <div class="col-md-4">
     <div class='event_photo'>
       <%= link_to_if( event.photo?, image_tag(event.photo.url(:medium), class:"rounded"),event.photo.url){ } %>
     </div>
   </div>
-  <div class="col-8">
-    <div class='row'>
-      <address class='col-12'>
+  <div class="col-md-8">
+      <address>
         <div class='location'> <%= link_to_if event.location_url?, event.location_name, event.location_url %> </div>
         <div class='address'> <%= event.address %> </div>
         <div class='phone'> <%= event.location_phone %> </div>
       </address>
-    </div>
+    <%= event.google_map %>
     <div class='row <%= photographer?(event) %>'>
       <div class='photographer col-12'><span>Event Photographer:</span> <%= link_to_if event.photographer_url?, event.photographer_name, event.photographer_url %></div>
     </div>
-    <%= event.google_map %>
-    <div class="row">
-      <div class="col-12 description">
-        <%= markdown(event.description) %>
-      </div>
-    </div>
+
+    <%= markdown(event.description) %>
 
     <div class='row'>
       <div class='col'>

--- a/spec/features/event_management_spec.rb
+++ b/spec/features/event_management_spec.rb
@@ -41,7 +41,6 @@ feature 'Manage Events', js: true do
       expect(page.find('.event-title .date_time').text).to eq date_time
       # lat/long are default values specified in spec/support/geocoder_stubs
       expect(page.find('.google_map_link')['href']).to eq "https://maps.google.com/?q=40.7143528%2C-74.0059731"
-      expect(page.find('.google_map_link>img')['src']).to eq "https://maps.google.com/maps/api/staticmap?size=250x100&zoom=12&sensor=false&zoom=16&markers=40.7143528%2C-74.0059731"
       # <a href="/system/event_photo/31/original/20180327_210243.jpg?1529672940">
       #   <img src="/system/event_photo/31/medium/20180327_210243.jpg?1529672940">
       # </a>


### PR DESCRIPTION
Fixes for mobile view of events index.  

Switch Google Maps to be just a link instead of rendering a static map due to removal of google maps static map free tier.  