### PR TITLE
Dog gallery sort update

### DIFF
--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -249,13 +249,13 @@ class Dog < ApplicationRecord
   end
 
   def self.status_order
-    order("
+    order(Arel.sql("
       CASE
         WHEN status = 'adoptable' THEN '1'
         WHEN status = 'coming soon' THEN '2'
         WHEN status = 'adoption pending' THEN '3'
       END
-      ")
+      "))
   end
 
   def to_petfinder_status

--- a/spec/controllers/dogs_gallery_controller_spec.rb
+++ b/spec/controllers/dogs_gallery_controller_spec.rb
@@ -51,8 +51,11 @@ require 'rails_helper'
 describe Dogs::GalleryController, type: :controller do
   describe 'GET #index' do
     let!(:adoptable_dog) { create(:dog, status: 'adoptable', tracking_id: 102) }
-    let!(:adoption_pending_dog) { create(:dog, status: 'adoption pending', tracking_id: 105) }
+    let!(:adoption_pending_dog) { create(:dog, status: 'adoption pending', tracking_id: 99) }
+    let!(:adoption_pending_dog2) { create(:dog, status: 'adoption pending', tracking_id: 105) }
     let!(:coming_soon_dog) { create(:dog, status: 'coming soon', tracking_id: 100) }
+    let!(:coming_soon_dog2) { create(:dog, status: 'coming soon', tracking_id: 109) }
+    let!(:adoptable_dog2) { create(:dog, status: 'adoptable', tracking_id: 110) }
 
     let!(:adopted_dog) { create(:dog, status: 'adopted', tracking_id: 1) }
     let!(:on_hold_dog) { create(:dog, status: 'on hold', tracking_id: 2) }
@@ -60,14 +63,14 @@ describe Dogs::GalleryController, type: :controller do
 
     subject(:get_index) { get :index, params: {} }
 
-    it 'Only adoptable, adoption pending or coming soon dogs should be displayed in order by tracking id' do
+    it 'Only adoptable, coming soon and adoption pending dogs should be displayed respectively in order by status then tracking id' do
       get_index
-      expect(assigns(:dogs)).to eq([coming_soon_dog, adoptable_dog, adoption_pending_dog])
+      expect(assigns(:dogs)).to eq([adoptable_dog, adoptable_dog2, coming_soon_dog, coming_soon_dog2, adoption_pending_dog, adoption_pending_dog2])
     end
 
     it 'with autocomplete parameter set all dogs are returned' do
       get :index, params: {autocomplete: true}
-      expect(assigns(:dogs)).to match_array([adoptable_dog, adoption_pending_dog, coming_soon_dog, adopted_dog, on_hold_dog, not_available_dog])
+      expect(assigns(:dogs)).to match_array([adoptable_dog, adoptable_dog2, adoption_pending_dog, adoption_pending_dog2, coming_soon_dog, coming_soon_dog2, adopted_dog, on_hold_dog, not_available_dog])
     end
   end
 


### PR DESCRIPTION
Adoptable dogs will be displayed first, followed by coming soon dogs and then adoption pending. Within each of these three groups, dogs will continue to be sorted in ascending order by their tracking id numbers. 