### PR TITLE
fixing adopapet sync test

### DIFF
--- a/spec/tasks/adoptapet_sync_spec.rb
+++ b/spec/tasks/adoptapet_sync_spec.rb
@@ -9,7 +9,7 @@ describe 'adoptapet_sync:export_upload', type: :task do
     let(:foster) { FactoryBot.create(:foster, region: "VA") }
     let!(:dog) { FactoryBot.create(:dog, status: 'adoptable', foster_id: foster.id, photos_attributes: [photo0,photo1,photo2,photo3,photo4].map(&:attributes)) }
     let!(:rake){ task.execute }
-    let(:recent_photos){ Dog.first.photos.sort_by{|photo| photo.updated_at}.reverse[0..3]}
+    let(:recent_photos){ Dog.first.photos.visible.sort_by{|photo| photo.position}}
     let(:photo_urls){ recent_photos.map{|photo| photo.photo.url(:large)} }
     let(:csv) { CSV.read( '/tmp/adoptapet/pets_VA.csv' ) }
 
@@ -17,7 +17,7 @@ describe 'adoptapet_sync:export_upload', type: :task do
       csv_photos = csv.first[16..19]
       # just confirming recent_photos are the ones we want to upload
       # expect most recent first
-      expect(recent_photos.map(&:updated_at)).to be_sorted(:descending)
+      expect(recent_photos.map(&:updated_at)).to be_sorted(:ascending)
       expect(csv_photos).to eq photo_urls
     end
   end

--- a/spec/tasks/adoptapet_sync_spec.rb
+++ b/spec/tasks/adoptapet_sync_spec.rb
@@ -10,14 +10,14 @@ describe 'adoptapet_sync:export_upload', type: :task do
     let!(:dog) { FactoryBot.create(:dog, status: 'adoptable', foster_id: foster.id, photos_attributes: [photo0,photo1,photo2,photo3,photo4].map(&:attributes)) }
     let!(:rake){ task.execute }
     let(:recent_photos){ Dog.first.photos.visible.sort_by{|photo| photo.position}}
-    let(:photo_urls){ recent_photos.map{|photo| photo.photo.url(:large)} }
+    let(:photo_urls){ recent_photos[0..3].map{|photo| photo.photo.url(:large)} }
     let(:csv) { CSV.read( '/tmp/adoptapet/pets_VA.csv' ) }
 
     it "should include most recent four photos for a dog" do
       csv_photos = csv.first[16..19]
       # just confirming recent_photos are the ones we want to upload
       # expect most recent first
-      expect(recent_photos.map(&:updated_at)).to be_sorted(:ascending)
+      expect(recent_photos.map(&:position)).to be_sorted(:ascending)
       expect(csv_photos).to eq photo_urls
     end
   end


### PR DESCRIPTION
Any idea what I'm missing here?

I made a change in 160eed302cf0cdecfc6ee5abcd147c985cc5f28a to the adoptapet sync.   Change makes the adoptapet sync send the 4 top ranked photos by position order instead of 4 most recent uploaded photos.  

I didn't update the test 👎 

Trying to make right on that, but can't seem to get this thing green.  Any idea what I'm missing?
```
Failure/Error: expect(csv_photos).to eq photo_urls

       expected: ["/system/test/photos/0c3e99740ee5a5cb5b6b3ea702e40cf86fcda327.jpeg", "/system/test/photos/4fb926fd55...4b0cebf79b9792ff3a21e389.jpeg", "/system/test/photos/9727826a3cc0fe0d4cc94b974c69a4786035bdf3.jpeg"]
            got: ["/system/test/photos/0c3e99740ee5a5cb5b6b3ea702e40cf86fcda327.jpeg", "/system/test/photos/4fb926fd55...15be2af5a98040e0ce7f8af3.jpeg", "/system/test/photos/aefff0bcc9c49ce64b0cebf79b9792ff3a21e389.jpeg"]
```