### PR TITLE
migrate to webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ group :test do
   gem 'capybara'
   gem 'capybara-screenshot'
   gem 'capybara-selenium'
-  gem 'chromedriver-helper'
+  gem 'webdrivers'
   gem 'coveralls', require: false
   gem 'database_cleaner'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,6 @@ GEM
     annotate (2.7.4)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     audited (4.8.0)
@@ -117,9 +115,6 @@ GEM
       timers (~> 4.0.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chronic (0.10.2)
     clearance (1.16.1)
       bcrypt
@@ -193,7 +188,6 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     i18n_data (0.8.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jmespath (1.4.0)
     json (2.1.0)
@@ -225,6 +219,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
+    net_http_ssl_fix (0.0.10)
     newrelic_rpm (6.0.0.351)
     nio4r (2.3.1)
     nokogiri (1.10.1)
@@ -420,6 +415,11 @@ GEM
     unicorn (5.5.0.1.g6836)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    webdrivers (3.7.2)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -450,7 +450,6 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   capybara-selenium
-  chromedriver-helper
   clearance
   countries
   coveralls
@@ -504,6 +503,7 @@ DEPENDENCIES
   to_xls
   uglifier
   unicorn (~> 5.5.0.1.g6836)
+  webdrivers
   whenever (~> 0.9.4)
   will_paginate
 

--- a/spec/drivers/selenium_chrome_headless.rb
+++ b/spec/drivers/selenium_chrome_headless.rb
@@ -1,7 +1,7 @@
 Capybara.register_driver :selenium_chrome_headless do |app|
+  Webdrivers::Chromedriver.version = '2.40'
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w[headless disable-gpu window-size=1366,2000] }
   )
   Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
 end
-

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'capybara/rspec'
 require 'capybara/rails'
 require 'capybara-screenshot/rspec'
 require 'selenium/webdriver'
+require 'webdrivers'
 require 'drivers/selenium_chrome_headless'
 require 'drivers/selenium_firefox_headless'
 require 'drivers/selenium_firefox'
@@ -39,7 +40,7 @@ else # browserstack testing
 
   # Code to stop browserstack local after end of test
   at_exit do
-    @bs_local.stop unless @bs_local.nil? 
+    @bs_local.stop unless @bs_local.nil?
   end
 end
 


### PR DESCRIPTION
tmp lock chromedriver to 2.40 to keep tests green