### PR TITLE
comments are now editable on touch devices

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -14,7 +14,7 @@
 
 $( function () {
 
-    $(document).on('click', '.toggle-edit-comment', function(e){
+    $(document).on('click touchstart', '.toggle-edit-comment', function(e){
       var $parent = $(e.target).parents('form.edit_comment');
       isEditing = $($parent).data("editing");
 


### PR DESCRIPTION
clicking the edit button on a comment when using an iPad or iPhone didn't work.  Needed to also watch for the `touchstart` event to get the toggle working