### PR TITLE
closes #1403 add user permission auditing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,7 @@
 #  active                       :boolean          default(FALSE), not null
 
 class User < ApplicationRecord
+  audited only: %i[admin edit_dogs edit_my_adopters edit_all_adopters locked edit_events complete_adopters add_dogs ban_adopters dl_resources dl_locked_resources active admin_comment medical_behavior_permission], on: [:update]
   include Clearance::User
   include Filterable
 
@@ -237,6 +238,10 @@ class User < ApplicationRecord
 
   def has_location?
     [city, region].all?
+  end
+
+  def audits_sorted
+    audits.sort_by(&:created_at).reverse!
   end
 
   private

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -255,9 +255,13 @@
       <div class="span6">
       </div>
         <% if is_admin? %>
-            <div class="row6">
-              <h4>Admin Notes</h4>
-              <p><%= @user.admin_comment %></p>
-            </div>
+          <div class="row6">
+            <h4>Admin Notes</h4>
+            <p><%= @user.admin_comment %></p>
+          </div>
+          <div class="row6">
+            <h4>Permission Change History</h4>
+            <p><%= render @user.audits_sorted %></p>
+          </div>
         <% end %>
     </div>


### PR DESCRIPTION
Tracks all changes to a User's permissions, and makes history visible on user's show page.