### PR TITLE
Bump geocoder from 1.4.9 to 1.6.1 with test fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
       railties (>= 3.2, < 6.1)
     friendly_id (5.3.0)
       activerecord (>= 4.0.0)
-    geocoder (1.4.9)
+    geocoder (1.6.1)
     gibbon (3.3.1)
       faraday (>= 0.9.1)
       multi_json (>= 1.11.0)

--- a/spec/support/geocoder_stubs.rb
+++ b/spec/support/geocoder_stubs.rb
@@ -3,8 +3,7 @@ Geocoder.configure(:lookup => :test)
 Geocoder::Lookup::Test.set_default_stub(
   [
     {
-      'latitude'     => 40.7143528,
-      'longitude'    => -74.0059731,
+      'coordinates'  => [40.7143528, -74.0059731],
       'address'      => 'New York, NY, USA',
       'state'        => 'New York',
       'state_code'   => 'NY',


### PR DESCRIPTION
adds fix for the geocoder test stub.