### PR TITLE
Updates clearance and fixes tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       aws-sdk-core (= 2.11.445)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     bcrypt_pbkdf (1.0.1)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
@@ -120,13 +120,13 @@ GEM
     chartkick (3.3.0)
     childprocess (3.0.0)
     chronic (0.10.2)
-    clearance (1.17.0)
-      actionmailer (>= 3.1)
-      activemodel (>= 3.1)
-      activerecord (>= 3.1)
-      bcrypt
-      email_validator (~> 1.4)
-      railties (>= 3.1)
+    clearance (2.1.0)
+      actionmailer (>= 5.0)
+      activemodel (>= 5.0)
+      activerecord (>= 5.0)
+      bcrypt (>= 3.1.1)
+      email_validator (~> 2.0)
+      railties (>= 5.0)
     climate_control (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
@@ -140,7 +140,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
-    crass (1.0.5)
+    crass (1.0.6)
     daemons (1.3.1)
     dalli (2.7.10)
     dante (0.2.0)
@@ -158,7 +158,7 @@ GEM
       dotenv (= 2.4.0)
       railties (>= 3.2, < 6.0)
     ed25519 (1.2.4)
-    email_validator (1.6.0)
+    email_validator (2.0.1)
       activemodel
     erubi (1.9.0)
     exception_notification (4.2.2)
@@ -264,7 +264,7 @@ GEM
     public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
-    rack (2.1.2)
+    rack (2.2.2)
     rack-cache (1.10.0)
       rack (>= 0.4)
     rack-mini-profiler (1.1.4)
@@ -406,7 +406,7 @@ GEM
       tins (~> 1.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
-    thor (0.20.3)
+    thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.8)
     timers (4.0.4)
@@ -524,4 +524,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/spec/features/cat/cat_search_spec.rb
+++ b/spec/features/cat/cat_search_spec.rb
@@ -11,7 +11,7 @@ feature 'visit manager view', js: true do
     it 'should direct the user to sign in' do
       expect { visit '/cats_manager?search=xyz' }.not_to raise_exception
       expect(page_heading).to eq 'Staff Sign in'
-      expect(flash_notice_message).to eq "Please sign in to continue."
+      expect(flash_notice_alert_message).to eq "Please sign in to continue."
 
       fill_and_submit(active_user)
       expect(page_heading).to eq "Cat Manager"

--- a/spec/features/dog/dog_search_spec.rb
+++ b/spec/features/dog/dog_search_spec.rb
@@ -11,7 +11,7 @@ feature 'visit manager view', js: true do
     it 'should direct the user to sign in' do
       expect { visit '/dogs_manager?search=xyz' }.not_to raise_exception
       expect(page_heading).to eq 'Staff Sign in'
-      expect(flash_notice_message).to eq "Please sign in to continue."
+      expect(flash_notice_alert_message).to eq "Please sign in to continue."
 
       fill_and_submit(active_user)
       expect(page_heading).to eq "Dog Manager"

--- a/spec/features/staff_resources_spec.rb
+++ b/spec/features/staff_resources_spec.rb
@@ -124,7 +124,7 @@ feature "folder management", js: true do
       it "should notify user that they are not permitted and redirect to sign in page" do
         visit edit_folder_path(folder)
         expect(page_heading).to eq "Staff Sign in"
-        expect(flash_notice_message).to eq "Please sign in to continue."
+        expect(flash_notice_alert_message).to eq "Please sign in to continue."
       end
     end
   end

--- a/spec/helpers/application_helpers.rb
+++ b/spec/helpers/application_helpers.rb
@@ -9,6 +9,11 @@ module ApplicationHelpers
     page.find('.alert.alert-notice').text
   end
 
+  def flash_notice_alert_message
+    sleep(1)
+    page.find('.alert.alert-alert').text
+  end
+
   def flash_success_message
     sleep(1)
     page.find('.alert.alert-success').text


### PR DESCRIPTION
Looks like they changed the class that gets applied to the default notice.  All tests should pass now with the upgrade to clearance 2.1