### PR TITLE
adopter add editable fields in form and rental

### DIFF
--- a/app/assets/javascripts/adoption_form.js
+++ b/app/assets/javascripts/adoption_form.js
@@ -137,6 +137,31 @@ $( function() {
       isRefEditing = !isRefEditing;
     });
 
+    var isRentalEditing = false;
+
+    $('#rental').on('click', 'a#toggle-edit-rental', function() {
+      if (isRentalEditing) {
+        // find all enabled fields in .edit-rent and disable them
+        $('form.edit-rental .to-disable').prop("disabled", true);
+        $('.rental-editable').hide();
+        $('.rental-read-only').show();
+        $('a#toggle-edit-rental').addClass('btn-primary').text("Edit Rental Info");
+        $('input.rental-save').removeClass('btn-primary');
+      }
+      else {
+        $('form.edit-rental :disabled')
+          .removeAttr('disabled')
+          .addClass('to-disable');
+
+        $('.rental-editable').show();
+        $('.rental-read-only').hide();
+        $('a#toggle-edit-rental').removeClass('btn-primary').text("Cancel");
+        $('input.rental-save').addClass('btn-primary');
+      }
+
+      isRentalEditing = !isRentalEditing;
+    });
+
     var isVetEditing = false;
 
     $('#otherpets').on('click', 'a#toggle-edit-vet', function() {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -215,7 +215,7 @@ div .fb-like {
   margin-top: 25px;
 }
 
-.editable, .ref-editable, .vet-editable {
+.editable, .ref-editable, .vet-editable, .rental-editable {
   display: none;
 }
 
@@ -227,7 +227,7 @@ div .fb-like {
   display: none;
 }
 
-.read-only, .ref-read-only, .vet-read-only {
+.read-only, .ref-read-only, .vet-read-only, .rental-read-only {
   padding: 5px;
 }
 

--- a/app/controllers/adopters_controller.rb
+++ b/app/controllers/adopters_controller.rb
@@ -148,6 +148,7 @@ class AdoptersController < ApplicationController
                                     :pre_q_costs,
                                     adoption_app_attributes:
                                     [
+                                      :id,
                                       :adopter_id,
                                       :spouse_name,
                                       :other_household_names,

--- a/app/views/adopters/_adopter_form.html.erb
+++ b/app/views/adopters/_adopter_form.html.erb
@@ -54,7 +54,6 @@
         <div class='editable'><%= f.text_field :phone %></div>
       </td>
     </tr>
-    <% if @adopter.other_phone? %>
       <tr>
         <th>Other Phone</th>
         <td>
@@ -62,7 +61,6 @@
           <div class='editable'><%= f.text_field :other_phone %></div>
         </td>
       </tr>
-    <% end %>
     <tr>
       <th>Best Time to Call</th>
       <td>
@@ -74,8 +72,13 @@
       <td><%= @adopter.adoption_app.spouse_name %></td>
     </tr>
     <tr>
+      <%= f.fields_for :adoption_app do |af|%>
       <th>Others in Household</th>
-      <td><%= @adopter.adoption_app.other_household_names %></td>
+      <td>
+        <div class='read-only'><%= @adopter.adoption_app.other_household_names %></div>
+        <div class='editable'><%= af.text_area :other_household_names %></div>
+      </td>
+      <% end %>
     </tr>
     <% if @adopter.adoption_app.verify_home_auth == true %>
     <tr>

--- a/app/views/adopters/_adopter_form.html.erb
+++ b/app/views/adopters/_adopter_form.html.erb
@@ -75,7 +75,7 @@
       <%= f.fields_for :adoption_app do |af|%>
       <th>Others in Household</th>
       <td>
-        <div class='read-only'><%= @adopter.adoption_app.other_household_names %></div>
+        <div class='read-only'><%= af.object.other_household_names %></div>
         <div class='editable'><%= af.text_area :other_household_names %></div>
       </td>
       <% end %>
@@ -138,12 +138,12 @@
     </tr>
     <% end %>
     <% if @adopter.adoption_app.adopter_age %>
-    <tr>
-      <th>
-        Adopter Age
-      </th>
-      <td><%= @adopter.adoption_app.adopter_age %></td>
-    </tr>
+      <tr>
+        <th>
+         Adopter Age
+        </th>
+        <td><%= @adopter.adoption_app.adopter_age %></td>
+      </tr>
     <% end %>
     <tr>
       <td colspan="2">

--- a/app/views/adopters/_adopter_rental.html.erb
+++ b/app/views/adopters/_adopter_rental.html.erb
@@ -1,26 +1,47 @@
-<table class="table table-striped table-bordered table-condensed">
-  <tr>
-    <th>Landlord Name</th>
-    <td><%= @adopter.adoption_app.landlord_name %></td>
-  </tr>
-  <tr>
-    <th>Landlord's Phone</th>
-    <td><%= @adopter.adoption_app.landlord_phone %></td>
-  </tr>
-  <tr>
-    <th>Landlord's Email</th>
-    <td>
-      <% if @adopter.adoption_app.landlord_email.present? %>
-        <%= mail_to @adopter.adoption_app.landlord_email %>
-      <% end %>
-    </td>
-  </tr>
-  <tr>
-    <th>Pet Restrictions at Rental</th>
-    <td><%= @adopter.adoption_app.rent_dog_restrictions %></td>
-  </tr>
-  <tr>
-    <th>Expected Rental Costs</th>
-    <td><%= @adopter.adoption_app.rent_costs %></td>
-  </tr>
-</table>
+<%= form_for @adoption_app, html: { class: 'form-horizontal edit-rental' } do |f| %>
+  <table class="table table-striped table-bordered table-condensed">
+    <tr>
+      <th>Landlord Name</th>
+      <td>
+        <div class='rental-read-only'><%= f.object.landlord_name %></div>
+        <div class='rental-editable'><%= f.text_field :landlord_name %></div>
+      </td>
+    </tr>
+    <tr>
+      <th>Landlord's Phone</th>
+      <td>
+        <div class='rental-read-only'><%= f.object.landlord_phone %></div>
+        <div class='rental-editable'><%= f.text_field :landlord_phone %></div>
+      </td>
+    </tr>
+    <tr>
+      <th>Landlord's Email</th>
+      <td>
+        <% if f.object.landlord_email.present? %>
+          <div class='rental-read-only'><%= mail_to f.object.landlord_email %></div>
+        <% else %>
+          <div class='rental-read-only'><%= f.object.landlord_email %></div>
+        <% end %>
+        <div class='rental-editable'><%= f.text_field :landlord_email %></div>
+      </td>
+    </tr>
+    <tr>
+      <th>Pet Restrictions at Rental</th>
+      <td>
+        <div class='rental-read-only'><%= f.object.rent_dog_restrictions %></div>
+        <div class='rental-editable'><%= f.text_area :rent_dog_restrictions %></div>
+      </td>
+    </tr>
+    <tr>
+      <th>Expected Rental Costs</th>
+      <td>
+        <div class='rental-read-only'><%= f.object.rent_costs %></div>
+        <div class='rental-editable'><%= f.text_area :rent_costs %></div>
+      </td>
+    </tr>
+  </table>
+  <p>
+    <a id="toggle-edit-rental" class="btn btn-primary">Edit Rental Info</a>
+    <%= f.submit "Save Rental Info", class: "btn rental-save", disabled: "disabled" %>
+  </p>
+<% end %>

--- a/app/views/adopters/steps/_rental.html.erb
+++ b/app/views/adopters/steps/_rental.html.erb
@@ -28,7 +28,7 @@
       <%= af.label :rent_costs, "How will your rental costs increase by having a pet?", :class => "control-label" %>
       <div class="controls">
         <%= af.text_area :rent_costs, :class => "required input-xxlarge", :rows => "3" %>
-        <span class="help-inline">Pet Deposts and Rent Increases</span>
+        <span class="help-inline">Pet Deposits and Rent Increases</span>
       </div>
     </div>
 </div>

--- a/spec/features/edit_rental_spec.rb
+++ b/spec/features/edit_rental_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+feature 'Edit Rental Info Form', js: true do
+    let!(:adopter) {create(:adopter, :with_app) }
+
+    scenario "Admin is able to edit rental info", js: true do
+
+        sign_in_as_admin
+        visit adopter_path(adopter)
+
+        click_link('Rental')
+        expect(page).to have_content(adopter.adoption_app.landlord_name)
+
+        expect(first('.rental-read-only', visible: false)).to be_visible
+        expect(first('.rental-editable', visible: false)).not_to be_visible
+
+        find('#toggle-edit-rental').click
+
+        expect(first('.rental-read-only', visible: false)).not_to be_visible
+        expect(first('.rental-editable', visible: false)).to be_visible
+
+        find('#toggle-edit-rental').click
+
+        expect(first('.rental-read-only', visible: false)).to be_visible
+        expect(first('.rental-editable', visible: false)).not_to be_visible
+   
+    end
+
+    scenario "Admin edits rental", js: true do
+
+        sign_in_as_admin
+
+        visit adopter_path(adopter)
+        click_link('Rental')
+
+        expect(page).to have_content(adopter.adoption_app.landlord_name)
+
+        find('#toggle-edit-rental').click
+        fill_in('adoption_app_landlord_name', with: 'The Landlord')
+        click_button('Save Rental Info')
+
+        click_link('Rental')
+        expect(page).to have_content('The Landlord')
+    end
+end


### PR DESCRIPTION
Makes other_household_names and other_phone editable
Makes rental info editable
Fixes typo on _rental.html.erb

Currently appears on history tab, but editing the info in _adopter_form.html.erb returns a unrecognized parameters :id error. 

will close #1569 and #1072 