### PR TITLE
Remove Firefox test job on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ bundler_args: "--without production"
 addons:
   artifacts: true
   postgresql: '9.6'
-  firefox: latest
   apt:
     packages:
     - google-chrome-stable
@@ -24,16 +23,10 @@ env:
   - secure: YmVza5uaDsncEQ+8kq0XOCcrBP6VFHfHTPp0W0VpU0iq1vtCeWQGIUYQtvvxPU7O1sDzb+U7cx+Sn8aFNzxsHHwP0zLcrtPcwT1mD18XANPTmcmrKSQHozeYzgdyi7c2c/zymLr/i3KmwUvAhQe89Qt2ZmgepuRyg3oRj3VLMNI=
   matrix:
   - BROWSER=chrome_headless SUITE=spec/
-  - BROWSER=firefox_headless SUITE=spec/features
 script:
 - RAILS_ENV=test bundle exec rake db:migrate --trace
 - bundle exec rake db:test:prepare
 - BROWSER=$BROWSER bundle exec rspec $SUITE
-before_install:
-- wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
-- mkdir geckodriver
-- tar -xzf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver
-- export PATH=$PATH:$PWD/geckodriver
 before_script:
 - psql -c 'create database travis_ci_test;' -U postgres
 - cp config/database.yml.travis config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ script:
 - bundle exec rake db:test:prepare
 - BROWSER=$BROWSER bundle exec rspec $SUITE
 before_install:
-- wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
+- wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
 - mkdir geckodriver
-- tar -xzf geckodriver-v0.21.0-linux64.tar.gz -C geckodriver
+- tar -xzf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver
 - export PATH=$PATH:$PWD/geckodriver
 before_script:
 - psql -c 'create database travis_ci_test;' -U postgres


### PR DESCRIPTION
Removing rspec run using Firefox/geckodriver as it takes twice as long to run  as our chrome based tests and throws false failures often.  

Since we're using an established front end framework, risk of major issues from Chrome to Firefox are fairly low.  