### PR TITLE
Feature/split user tabs 1096

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,6 +193,7 @@ class User < ApplicationRecord
                    has_dogs: :has_own_dogs,
                    has_fence: :has_fenced_yard,
                    has_parvo_house: :parvo_house,
+                   locked: :locked,
                    medical_behavior: :medical_behavior_permission,
                    newsletter: :writes_newsletter,
                    photographer: :is_photographer,
@@ -201,7 +202,8 @@ class User < ApplicationRecord
                    social_media: :social_media_manager,
                    training_team: :training_team,
                    translator: :translator,
-                   transporter: :is_transporter }
+                   transporter: :is_transporter,
+                  }
 
   FILTER_FLAGS.each do |param,attr|
     scope :"#{param}", -> (status = true) { where "#{attr}": status}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
 
   scope :unlocked,                -> { where(locked: false) }
 
-  scope :inactive_volunteer,      -> (status = false) { where(active: status)}
+  scope :inactive_volunteer,      -> (status = false) { where(active: status, locked: status)}
   scope :house_type,              -> (type) { where(house_type: type) }
 
   HASH_SECRET = "5b0a2cd2064828d34ad737f9f6a586fb773297a01639c2b3ff24fcb7"

--- a/app/models/user_searcher.rb
+++ b/app/models/user_searcher.rb
@@ -59,7 +59,7 @@ class UserSearcher
                  :has_fence, :puppies_ok, :has_parvo_house, :transporter, :training_team,
                  :foster_mentor, :translator, :public_relations, :fundraising, :medical_behavior,
                  :boarding_buddy, :social_media, :graphic_designer, :active_volunteer, :inactive_volunteer,
-                 :available_to_foster
+                 :available_to_foster, :locked
                 )
   end
 end

--- a/app/models/user_searcher.rb
+++ b/app/models/user_searcher.rb
@@ -59,7 +59,7 @@ class UserSearcher
                  :has_fence, :puppies_ok, :has_parvo_house, :transporter, :training_team,
                  :foster_mentor, :translator, :public_relations, :fundraising, :medical_behavior,
                  :boarding_buddy, :social_media, :graphic_designer, :active_volunteer, :inactive_volunteer,
-                 :available_to_foster, :locked
+                 :available_to_foster, :locked, :unlocked
                 )
   end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -83,7 +83,7 @@
     <%= link_to "Active Volunteers", users_path(active_volunteer: :true, location: params[:location]) %>
   </li>
   <li class="<%='active' if params[:inactive_volunteer] %>">
-    <%= link_to "Inactive Volunteers", users_path(inactive_volunteer: :true) %>
+    <%= link_to "Inactive Volunteers", users_path(inactive_volunteer: :true, location: params[:location]) %>
   </li>
   <li class="<%= 'active' if params[:locked] %>">
     <%= link_to "Locked Volunteers", users_path(locked: :true, location: params[:location]) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -83,7 +83,10 @@
     <%= link_to "Active Volunteers", users_path(active_volunteer: :true, location: params[:location]) %>
   </li>
   <li class="<%='active' if params[:inactive_volunteer] %>">
-    <%= link_to "Inactive Volunteers", users_path(active_volunteer: :false, location: params[:location]) %>
+    <%= link_to "Inactive Volunteers", users_path(inactive_volunteer: :true) %>
+  </li>
+  <li class="<%= 'active' if params[:locked] %>">
+    <%= link_to "Locked Volunteers", users_path(locked: :true, location: params[:location]) %>
   </li>
 </ul>
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -128,10 +128,10 @@ describe UsersController, type: :controller do
         expect(assigns(:users)).to match_array([smith, admin, active_user])
       end
 
-      it 'returns the inactive team members' do
-        smith = create(:user, name: 'Jane Smithbot', active: false)
+      it 'returns the inactive not locked team members' do
+        smith = create(:user, name: 'Jane Smithbot', locked: true)
         get :index, params: { inactive_volunteer: true }
-        expect(assigns(:users)).to match_array([inactive_user, smith])
+        expect(assigns(:users)).to match_array([inactive_user])
       end
 
       it 'returns the locked team members' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -127,6 +127,18 @@ describe UsersController, type: :controller do
         get :index, params: { active_volunteer: true }
         expect(assigns(:users)).to match_array([smith, admin, active_user])
       end
+
+      it 'returns the inactive team members' do
+        smith = create(:user, name: 'Jane Smithbot', active: false)
+        get :index, params: { inactive_volunteer: true }
+        expect(assigns(:users)).to match_array([inactive_user, smith])
+      end
+
+      it 'returns the locked team members' do
+        smith = create(:user, name: 'Jane Smithbot', locked: true)
+        get :index, params: { locked: true }
+        expect(assigns(:users)).to match_array([smith])
+      end
     end
 
     context 'logged in as an inactive user' do


### PR DESCRIPTION
Adds Locked Volunteers tab to user index
Modifies inactive_volunteer to exclude locked users 
Modifies users_controller_spec.rb to add
    - returns the inactive not locked users
    - returns the locked users 

Closes #1096 