### PR TITLE
#1584 Filter applications

### DIFF
--- a/app/controllers/adopters_controller.rb
+++ b/app/controllers/adopters_controller.rb
@@ -52,7 +52,7 @@ class AdoptersController < ApplicationController
 
   def index
     session[:last_search] = request.url
-    @adopters = AdopterSearcher.search(params: params)
+    @adopters = AdopterSearcher.search(params: params, user_id: current_user.id)
   end
 
   def show

--- a/app/models/adopter_searcher.rb
+++ b/app/models/adopter_searcher.rb
@@ -14,6 +14,7 @@
 
 class AdopterSearcher
   include ActionView::Helpers::NumberHelper
+
   PER_PAGE = 30
 
   STATUSES = [
@@ -28,12 +29,18 @@ class AdopterSearcher
 
   PHONE_CHECK = /\(?(?<areacode>[1]?[2-9]\d{2})\)?[\s-]?(?<prefix>[2-9]\d{2})[\s-]?(?<linenumber>[\d]{4})/i.freeze
 
-  def initialize(params: {})
+  def initialize(params: {}, user_id: user_id)
     @params = params
+    @user_id = user_id
   end
 
   def search
     @adopters = Adopter
+    if @params[:show] == "MyApplications"
+      @adopters = @adopters.where(assigned_to_user_id: @user_id)
+    elsif @params[:show] == "OpenApplications"
+      @adopters = @adopters.where(assigned_to_user_id: nil)
+    end
 
     if @params[:search]
       if email_search?
@@ -57,8 +64,8 @@ class AdopterSearcher
     @adopters
   end
 
-  def self.search(params: {})
-    new(params: params).search
+  def self.search(params: {}, user_id: user_id)
+    new(params: params, user_id: user_id).search
   end
 
   private

--- a/app/models/adoption.rb
+++ b/app/models/adoption.rb
@@ -28,6 +28,8 @@ class Adoption < ApplicationRecord
   belongs_to :dog
   belongs_to :adopter
 
+  AMOUNT_TO_SHOW = ['MyApplications', 'OpenApplications', 'AllApplications']
+
   RELATION_TYPE = ['interested', 'adopted', 'returned',
         'pending adoption', 'pending return', 'trial adoption']
 

--- a/app/views/adopters/index.html.erb
+++ b/app/views/adopters/index.html.erb
@@ -2,9 +2,20 @@
   <div class="span12">
     <h1><%= t('.title') %></h1>
     <ul class="nav nav-pills">
-      <li class="active"><a href="#">My Apps</a></li>
-      <li><a href="#">Open Apps</a></li>
-      <li><a href="#">All Apps</a></li>
+      <%Adoption::AMOUNT_TO_SHOW.each do |show|%>
+        <%if show == params[:show]%>
+          <li class="active">
+        <%else%>
+          <li>
+        <%end%>
+          <%=link_to show.titleize, :controller => "adopters", :show => show %>
+          </li>
+      <%end%>
+      <%if params[:show] == nil%>
+        <li class= "active">
+      <%else%>
+        <li>
+      <%end%>
     </ul>
   </div>
 </div>
@@ -14,26 +25,26 @@
     <ul class="nav nav-tabs">
       <% Adopter::STATUSES.each do |status| %>
         <% if status == params[:status] %>
-        <li class="active">
-    <% else %>
-        <li>
-    <% end %>
-      <%= link_to status.titleize, :controller => "adopters", :status => status %>
-      </li>
-    <% end %>
+          <li class="active">
+        <% else %>
+          <li>
+        <% end %>
+        <%= link_to status.titleize, :controller => "adopters", :status => status, :show => params[:show] %>
+        </li>
+      <% end %>
       <% if params[:status] == nil %>
         <li class="active">
-    <% else %>
+      <% else %>
         <li>
-    <% end %>
-      <%= link_to "All", adopters_path %>
+      <% end %>
+      <%= link_to "All", :controller => "adopters", :show => params[:show]  %>
       </li>
       <% if params[:status] == "active" %>
         <li class="active">
-    <% else %>
+      <% else %>
         <li>
-    <% end %>
-      <%= link_to "Active", :controller => "adopters", :status => "active" %>
+      <% end %>
+      <%= link_to "Active", :controller => "adopters", :status => "active", :show => params[:show] %>
       </li>
     </ul>
   </div>

--- a/app/views/layouts/_topbar.html.erb
+++ b/app/views/layouts/_topbar.html.erb
@@ -70,7 +70,7 @@
               <ul class="dropdown-menu">
                 <li><%= link_to "Dashboard", dashboards_path %></li>
                 <% if can_edit_my_adopters? || can_edit_all_adopters? %>
-                  <li><%= link_to "Applications",  :controller => "adopters", :status => "active" %></li>
+                  <li><%= link_to "Applications",  :controller => "adopters", :status => "active", show: "MyApplications" %></li>
                 <% end %>
                 <% if current_user.active? || current_user.admin? %>
                   <li><%= link_to "Cat Manager", cats_manager_index_path %></li>

--- a/app/views/layouts/_topbar_bs41.html.erb
+++ b/app/views/layouts/_topbar_bs41.html.erb
@@ -65,7 +65,7 @@
           <div class="dropdown-menu">
               <%= link_to "Dashboard", dashboards_path, class: "nav-link" %>
             <% if can_edit_my_adopters? || can_edit_all_adopters? %>
-              <%= link_to "Applications",  adopters_path( status: "active"), class: "nav-link" %>
+              <%= link_to "Applications",  adopters_path( status: "active", show: "MyApplications"), class: "nav-link" %>
             <% end %>
             <% if current_user.active? || current_user.admin? %>
               <%= link_to "Cat Manager", cats_manager_index_path, class: "nav-link" %>

--- a/app/views/layouts/_topbar_user_bs41.html.erb
+++ b/app/views/layouts/_topbar_user_bs41.html.erb
@@ -2,7 +2,7 @@
   <nav class="nav nav-underline">
     <%= link_to "Dashboard", dashboards_path, class: "nav-link" %>
     <% if can_edit_my_adopters? || can_edit_all_adopters? %>
-      <%= link_to "Adopters", adopters_path( status: "active"), class: "nav-link "%>
+      <%= link_to "Adopters", adopters_path( status: "active", show: "MyApplications"), class: "nav-link "%>
     <% end %>
     <% if current_user.active? || current_user.admin? %>
       <%= link_to "DNA", banned_adopters_path, class: "nav-link" %>

--- a/spec/models/adopter_searcher_spec.rb
+++ b/spec/models/adopter_searcher_spec.rb
@@ -88,4 +88,40 @@ describe AdopterSearcher do
       end
     end
   end
+
+  describe 'display filtered adopters' do
+    let(:adopters_to_display) { AdopterSearcher.search(params: params, user_id: 1) }
+    let(:assigned_to_me) { create(:adopter, :with_app, status: 'approved', assigned_to_user_id: 1) }
+    let(:assigned_to_other) { create(:adopter, :with_app, status: 'approved', assigned_to_user_id: 2) }
+    let(:unassigned_to) { create(:adopter, :with_app, status: 'approved', assigned_to_user_id: nil) }
+
+    context 'my apps' do    
+      let(:params){{show: "MyApplications"}}
+      it 'filters by id when my apps is selected' do
+        expect(adopters_to_display).to include(assigned_to_me)
+        expect(adopters_to_display).to_not include(assigned_to_other)
+        expect(adopters_to_display).to_not include(assigned_to_other)
+      end
+    end
+
+    context 'open apps' do
+      let(:params){{show: "OpenApplications"}}
+      it 'filters unassigned apps when open apps is selected' do
+        expect(adopters_to_display).to include(unassigned_to)
+        expect(adopters_to_display).to_not include(assigned_to_me)
+        expect(adopters_to_display).to_not include(assigned_to_other)
+      end
+    end
+
+    context 'all apps' do
+      let(:params){{show: "AllApplications"}}
+      it 'show all active apps when all apps is selected' do
+        expect(adopters_to_display).to include(assigned_to_other)
+        expect(adopters_to_display).to_not include(unassigned_to)
+        expect(adopters_to_display).to_not include(assigned_to_me)
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
**Fulfills OPH_request, issue #1584**

Edits adopter_searcher.search
- Adopter list displayed according to the selected filtering button
- "All applications" does not add a filter to the list

Edits filtering buttons behavior:
- "My Applications" show applications assigned to the logged User
- "Open Applications" show applications that are unassigned
- "All Applications" show all applications

Adds 'display filtered adopters' in adopter_searcher_spec

_By default "My applications" are displayed (may break client expectations of seeing all applications when entering)_
