### PR TITLE
fix vet_info #1607

### DIFF
--- a/app/views/adopters/_adopter_form.html.erb
+++ b/app/views/adopters/_adopter_form.html.erb
@@ -12,9 +12,9 @@
 
         <% if @adopter.adoption_app.pets_branch == "no_pets" && @adopter.adoption_app.prev_pets_type.blank? %>
           <span class="label label-warning">First Time Pet Owner</span>
-        <% elsif @adopter.adoption_app.prev_pets_type == "Cats" && @adopter.dog_or_cat == "Dog" %>
+        <% elsif (@adopter.adoption_app.prev_pets_type == "Cats" || @adopter.adoption_app.prev_pets_type == "None") && (@adopter.adoption_app.current_pets_type == "Cats" || @adopter.adoption_app.current_pets_type == "None") && @adopter.dog_or_cat == "Dog" %>
           <span class="label label-warning">First Time Dog Owner</span>
-        <% elsif @adopter.adoption_app.prev_pets_type == "Dogs" && @adopter.dog_or_cat == "Cat"%>
+        <% elsif (@adopter.adoption_app.prev_pets_type == "Dogs" || @adopter.adoption_app.prev_pets_type == "None") && (@adopter.adoption_app.current_pets_type == "Dogs" || @adopter.adoption_app.current_pets_type == "None") && @adopter.dog_or_cat == "Cat"%>
           <span class="label label-warning">First Time Cat Owner</span>
         <% end %>
 

--- a/app/views/adopters/_adopter_other_pets_form.html.erb
+++ b/app/views/adopters/_adopter_other_pets_form.html.erb
@@ -4,7 +4,7 @@
         <th class="span2">Previously Owned Cats or Dogs?</th>
         <td>
           <div class='vet-read-only'><%= f.object.prev_pets_type %></div>
-          <div class='vet-editable'><%= f.select :prev_pets_type, options_for_select([['Dogs'], ['Cats'], ['Both']]), include_blank: true %></div>
+          <div class='vet-editable'><%= f.select :prev_pets_type, options_for_select([['Dogs'], ['Cats'], ['Both'], ['None']]), include_blank: true %></div>
         </td>
     </tr>
     <tr>

--- a/app/views/adopters/steps/_other_pets.html.erb
+++ b/app/views/adopters/steps/_other_pets.html.erb
@@ -14,6 +14,10 @@
         <%= af.radio_button :prev_pets_type, "Both", :class => "required" %>
         <span>Both</span>
       </label>
+      <label class="radio">
+        <%= af.radio_button :prev_pets_type, "None", :class => "required" %>
+        <span>None</span>
+      </label>
     </div>
    </div>
    <div class="control-group">
@@ -156,16 +160,14 @@
         <%= af.text_area :current_pets_uptodate_why, :class => "input-xxlarge", :rows => "3" %>
       </div>
     </div>
-  <div class="current-q">
     <h5>Please provide the name and phone number of a veterinarian who has seen these pets.</h5>
 
     <div class="control-group">
       <%= af.label :vet_info, "Veterinarian Name and Phone Number", :class => "control-label" %>
       <div class="controls">
-        <%= af.text_area :vet_info, :class => "input-xxlarge", :rows => "3" %>
+        <%= af.text_area :vet_info, :class => "required input-xxlarge", :rows => "3" %>
         <span class="help-inline">Failure to include your Vet's Phone Number will delay your application</span>
       </div>
     </div>
     <p><span class="label label-important">Important</span> Call your vet and give permission to release your pet records to Operation Paws for Homes.</p>
-  </div>
 </div>


### PR DESCRIPTION
- Makes Vet Info required and always visible 
- Adds 'None' option to prev_pets_type on application and editable
- Fixes First Time Dog / Cat label logic (adds in current_pet_types as a factor) 

closes #1607 