### PR TITLE
Feature 527: Adopter can directly link pets on their application

### DIFF
--- a/app/assets/javascripts/dog_link.js
+++ b/app/assets/javascripts/dog_link.js
@@ -53,6 +53,36 @@ $( function () {
     }
   });
 
+  $('select#dog_selected').change(function(){
+    var select = $(this);
+    $('#display_dogs').empty();
+    var result = ''
+    var pets_id = select.val();
+    for(id of pets_id){
+      if (!id) {
+        continue;
+      }
+      dogName = select.find("[value="+id+"]").text();
+      result = '<li>'+dogName+'</li>'
+      $('#display_dogs').append(result);
+    }
+  })
+
+  $('select#cat_selected').change(function(){
+    var select = $(this);
+    $('#display_cats').empty();
+    var result = ''
+    var pets_id = select.val();
+    for(id of pets_id){
+      if (!id) {
+        continue;
+      }
+      catName = select.find("[value="+id+"]").text();
+      result = '<li>'+catName+'</li>'
+      $('#display_cats').append(result);
+    }
+  })
+
 });
 
 function refresh_dogs() {

--- a/app/controllers/adopters_controller.rb
+++ b/app/controllers/adopters_controller.rb
@@ -66,6 +66,8 @@ class AdoptersController < ApplicationController
   end
 
   def new
+    @dogs = Dog.gallery_view
+    @cats = Cat.gallery_view
     @adopter = Adopter.new
     @adopter.adoption_app = AdoptionApp.new
     @adopter.dog_name = params[:dog_name]
@@ -75,9 +77,16 @@ class AdoptersController < ApplicationController
   end
 
   def create
+    @selected_dog = params[:prefered_pet][:dog_ids].reject(&:empty?)
+    @selected_cat = params[:prefered_pet][:cat_ids].reject(&:empty?)
     @adopter = Adopter.new(adopter_params)
     @adopter.status = 'new'
-
+    for id in @selected_dog
+        @adopter.adoptions.build(:adopter_id => @adopter.id, :relation_type => 'interested',:dog_id => id)
+    end
+    for id in @selected_cat
+      @adopter.cat_adoptions.build(:adopter_id => @adopter.id, :relation_type => 'interested', :cat_id => id)
+    end
     if @adopter.adoption_app.ready_to_adopt_dt.blank?
       @adopter.adoption_app.ready_to_adopt_dt = Date.today
     end

--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -301,6 +301,10 @@ class Cat < ApplicationRecord
   def persisted_comments
     comments.select(&:persisted?)
   end
+
+  def display_cat_information
+    "#{name.titleize} (#{size.titleize}-size, #{gender.titleize}, #{age} #{breeds.join(" x ").html_safe})"
+  end
 end
 
 CatsManager = Cat

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -296,6 +296,10 @@ class Dog < ApplicationRecord
   def persisted_comments
     comments.select(&:persisted?)
   end
+
+  def display_dog_information
+    "#{name.titleize} (#{size.titleize}-size, #{gender.titleize}, #{age} #{breeds.join(" x ").html_safe})"
+  end
 end
 
 DogsManager = Dog

--- a/app/views/adopters/steps/_dog.html.erb
+++ b/app/views/adopters/steps/_dog.html.erb
@@ -15,12 +15,29 @@
   </div>
   
   <div class="control-group">
-    <%= f.label :dog_name, "(Optional) What pets are you interested in?", :class => "control-label" %>
+    <%= f.label :dog_name, "(Optional) What pets are you interested in? (you may select more than one with the ctrl button, or select none by pressing \"Select dogs/cats\")", :class => "control-label" %>
     <div class="controls">
-      <%= f.text_field :dog_name %>
+    <table>
+      <tr>
+        <td>
+          <%= collection_select :prefered_pet, :dog_ids, @dogs, :id, :display_dog_information, {prompt: 'Select dogs'}, {multiple: true, size: 10, id: 'dog_selected'}%>
+        </td>
+        <td>
+          <%= collection_select :prefered_pet, :cat_ids, @cats, :id, :display_cat_information, {prompt: 'Select cats'}, {multiple: true, size: 10, id: 'cat_selected'}%>
+        </td>
+      </tr>
+    </table>
+    <div>
+      Selected dogs:
+        <span id='display_dogs'></span>
+      <br>
+      Selected cats:
+        <span id='display_cats'></span>
+    </div>
     </div>
   </div>
 
+  <br>
   <div class="control-group">
     <%= f.label :dog_reqs, "Describe the type of pet you want to adopt.  Please include the two traits that are most important to you.", :class => "control-label" %>
     <div class="controls">

--- a/spec/controllers/adopters_controller_spec.rb
+++ b/spec/controllers/adopters_controller_spec.rb
@@ -60,12 +60,22 @@ describe AdoptersController, type: :controller do
   describe 'POST create' do
     let(:adoption_app) { attributes_for(:adoption_app) }
     let(:adopter) { attributes_for(:adopter, adoption_app_attributes: adoption_app) }
+    let(:prefered_pet) { {dog_ids: ["", "1", "2"], cat_ids: [""]} }
 
     it 'creates an adopter' do
-      post :create, params: { adopter: adopter }
-
+      count_of_adopters = Adopter.count
+      post :create, params: { adopter: adopter, prefered_pet: prefered_pet }
+      expect(count_of_adopters+1).to eq Adopter.count
       expect(response).to redirect_to root_path(adoptapp: 'complete')
     end
+
+    it 'links adopter with dogs he/she is interested in' do
+      post :create, params: { adopter: adopter, prefered_pet: prefered_pet }
+      expect(Adoption.where(dog_id: 1).last.adopter_id).to eq Adopter.last.id
+      expect(Adoption.where(dog_id: 2).last.adopter_id).to eq Adopter.last.id
+      expect(CatAdoption.all.size).to eq 0
+    end
+
   end
 
   describe 'PUT update' do
@@ -181,4 +191,5 @@ describe AdoptersController, type: :controller do
       end
     end
   end
+
 end

--- a/spec/factories/cat.rb
+++ b/spec/factories/cat.rb
@@ -87,6 +87,10 @@ FactoryBot.define do
         status { Cat::ACTIVE_STATUSES.sample }
       end
 
+      trait :selectable_cat do
+        status { Cat::PUBLIC_STATUSES.sample }
+      end
+
       trait :primary_tabby do
         primary_breed_id { create(:cat_breed, name: 'Tabby').id }
         secondary_breed_id { nil }

--- a/spec/factories/dog.rb
+++ b/spec/factories/dog.rb
@@ -88,6 +88,10 @@ FactoryBot.define do
       status { Dog::ACTIVE_STATUSES.sample }
     end
 
+    trait :selectable_dog do
+      status { Dog::PUBLIC_STATUSES.sample }
+    end
+
     trait :primary_lab do
       primary_breed_id { create(:breed, name: 'Labrador Retriever').id }
       secondary_breed_id { nil }

--- a/spec/features/apply_to_adopt_spec.rb
+++ b/spec/features/apply_to_adopt_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Apply for Adoption' do
+  let!(:dog_to_select) { create(:dog, :selectable_dog) }
+  let!(:cat_to_select) { create(:cat, :selectable_cat) }
   scenario "Renter fills out adoption application", js: true do
     visit root_path
     within(:css, "div.actions") do
@@ -51,7 +53,8 @@ feature 'Apply for Adoption' do
     click_button('Next')
     expect(page).to have_content('Your New Pet')
     choose('adopter_dog_or_cat_dog')
-    fill_in('adopter_dog_name', with: 'Rex and Precious')
+    select(find("#dog_selected > option:nth-child(1)").text, from: 'dog_selected')
+    select(find("#cat_selected > option:nth-child(1)").text, from: 'cat_selected')
     fill_in('adopter_dog_reqs', with: 'Dog Under 50lbs')
     fill_in('adopter_why_adopt', with: 'Want to love them and hold them')
     fill_in('adopter_adoption_app_attributes_dog_exercise', with: 'Dog will go to the gym with me')
@@ -217,7 +220,8 @@ feature 'Apply for Adoption' do
     click_button('Next')
     expect(page).to have_content('Your New Pet')
     choose('adopter_dog_or_cat_dog')
-    fill_in('adopter_dog_name', with: 'Rex and Precious')
+    select(find("#dog_selected > option:nth-child(1)").text, from: 'dog_selected')
+    select(find("#cat_selected > option:nth-child(1)").text, from: 'cat_selected')
     fill_in('adopter_dog_reqs', with: 'Dog Under 50lbs')
     fill_in('adopter_why_adopt', with: 'Want to love them and hold them')
     fill_in('adopter_adoption_app_attributes_dog_exercise', with: 'Dog will go to the gym with me')
@@ -380,7 +384,8 @@ feature 'Apply for Adoption' do
     click_button('Next')
     expect(page).to have_content('Your New Pet')
     choose('adopter_dog_or_cat_dog')
-    fill_in('adopter_dog_name', with: 'Rex and Precious')
+    select(find("#dog_selected > option:nth-child(1)").text, from: 'dog_selected')
+    select(find("#cat_selected > option:nth-child(1)").text, from: 'cat_selected')
     fill_in('adopter_dog_reqs', with: 'Dog Under 50lbs')
     fill_in('adopter_why_adopt', with: 'Want to love them and hold them')
     fill_in('adopter_adoption_app_attributes_dog_exercise', with: 'Dog will go to the gym with me')


### PR DESCRIPTION
# Feature 527
## Changes proposed on this pull request:
* [dog_link.js](https://github.com/ophrescue/RescueRails/blob/master/app/assets/javascripts/dog_link.js)
    * Add dynamic behavior when selecting dog/cats (the page lists current selection)
* [adopter_controller.rb](https://github.com/ophrescue/RescueRails/blob/master/app/controllers/adopters_controller.rb) 
    * Add `@dog` and `@cat` variables that retrieve pets available to be selected
    * `line 84`: for loop that creates new `adoption`/`cat_adoption` and link them to current adopter
* [cat.rb](https://github.com/ophrescue/RescueRails/blob/master/app/models/cat.rb) & [dog.rb](https://github.com/ophrescue/RescueRails/blob/master/app/models/dog.rb)
    * Add `display_cat_information` and `display_dog_information` methods to populate `collection_select` on [_dog.html.erb](https://github.com/ophrescue/RescueRails/blob/master/app/views/adopters/steps/_dog.html.erb)
* [_dog.html.erb](https://github.com/ophrescue/RescueRails/blob/master/app/views/adopters/steps/_dog.html.erb)
    * Replace `text_field` with `collection_select`
    * Add Selected dogs/cats list
* **Test:** [adopter_controller_spec.rb ](https://github.com/ophrescue/RescueRails/blob/master/spec/controllers/adopters_controller_spec.rb)
    * Extend `'creates an adopter'` to verify that number of adopter increases
    * Add `'links adopter with dogs he/she is interested in'`
    * Add `selectable_dog` and `selectable_cat` to [dog](https://github.com/ophrescue/RescueRails/blob/master/spec/factories/dog.rb) and [cat](https://github.com/ophrescue/RescueRails/blob/master/spec/factories/cat.rb) factories
    * Add select of dog/cat option in [apply_to_adopt_spec.rb](https://github.com/ophrescue/RescueRails/blob/master/spec/features/apply_to_adopt_spec.rb)