### PR TITLE
Feature 762: Microchip validation

### DIFF
--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -104,6 +104,10 @@ class Cat < ApplicationRecord
 
   validates :tracking_id, uniqueness: true, presence: true
 
+  validates :microchip, uniqueness: true, allow_blank: true
+  
+  validate :microchip_check
+
   STATUSES = ['adoptable', 'adopted', 'adoption pending', 'trial adoption',
         'on hold', 'not available', 'return pending', 'coming soon', 'completed'].freeze
   validates_inclusion_of :status, in: STATUSES
@@ -175,6 +179,26 @@ class Cat < ApplicationRecord
         .sort_with_search_term_matches_first(search_term)
     else
       select(:name, :id)
+    end
+  end
+
+  def microchip_check
+    if !self.microchip.nil?
+      case self.microchip.length
+      when 0
+        return
+      when 10
+        valid_format = /\A[a-zA-Z0-9]{10}\z/
+        err_message = ": 10 digit format -> This format accepts only numbers and characters"
+      when 15
+        valid_format = /\A9[0-9]{14}\z/
+        err_message = ": 15 digits format -> This format needs to start with 9, and accepts only numbers"
+      else
+        return errors.add(:microchip, "length must be 10 or 15")
+      end
+      if !valid_format.match?(self.microchip)
+        return errors.add(:microchip, err_message)
+      end
     end
   end
 

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -99,6 +99,10 @@ class Dog < ApplicationRecord
   validates :name, presence: true,
            length: { maximum: 75 },
            uniqueness: { case_sensitive: false }
+  
+  validates :microchip, uniqueness: true, allow_blank: true
+  
+  validate :microchip_check
 
   validates :tracking_id, uniqueness: true, presence: true
 
@@ -170,6 +174,26 @@ class Dog < ApplicationRecord
         .sort_with_search_term_matches_first(search_term)
     else
       select(:name, :id)
+    end
+  end
+
+  def microchip_check
+    if !self.microchip.nil?
+      case self.microchip.length
+      when 0
+        return
+      when 10
+        valid_format = /\A[a-zA-Z0-9]{10}\z/
+        err_message = ": 10 digit format -> This format accepts only numbers and characters"
+      when 15
+        valid_format = /\A9[0-9]{14}\z/
+        err_message = ": 15 digits format -> This format needs to start with 9, and accepts only numbers"
+      else
+        return errors.add(:microchip, "length must be 10 or 15")
+      end
+      if !valid_format.match?(self.microchip)
+        return errors.add(:microchip, err_message)
+      end
     end
   end
 

--- a/app/views/cats/manager/_cat_form.html.erb
+++ b/app/views/cats/manager/_cat_form.html.erb
@@ -39,8 +39,9 @@
       </div>
 
       <div class="form-group row">
-        <%= f.label :microchip, class: 'col-form-label col-form-label-sm col-4'  %>
-        <%= f.text_field :microchip, class: 'form-control form-control-sm col-6' %>
+        <%= f.label :microchip, class: 'col-form-label col-form-label-sm col-4', 'data-bootstrap41': true  %>
+        <%= f.text_field :microchip, class: "form-control form-control-sm col-6 #{validation_class_for(f,:microchip) }", 'data-bootstrap41': true %>
+        <div class='invalid-feedback col-sm-6 offset-4'><%= validation_error_message_for(f,:microchip) %></div>
       </div>
 
       <div class="form-group row">

--- a/app/views/dogs/manager/_dog_form.html.erb
+++ b/app/views/dogs/manager/_dog_form.html.erb
@@ -39,8 +39,9 @@
       </div>
 
       <div class="form-group row">
-        <%= f.label :microchip, class: 'col-form-label col-form-label-sm col-4'  %>
-        <%= f.text_field :microchip, class: 'form-control form-control-sm col-6' %>
+        <%= f.label :microchip, class: 'col-form-label col-form-label-sm col-4', 'data-bootstrap41': true  %>
+        <%= f.text_field :microchip, class: "form-control form-control-sm col-6 #{validation_class_for(f,:microchip) }", 'data-bootstrap41': true %>
+        <div class='invalid-feedback col-sm-6 offset-4'><%= validation_error_message_for(f,:microchip) %></div>
       </div>
 
       <div class="form-group row">

--- a/spec/factories/cat.rb
+++ b/spec/factories/cat.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
         nn.gsub(/(\W|\s)/,'').titlecase
       }
       status {  Cat::STATUSES.sample }
-      sequence(:microchip) { |n| "MC-#{n}" }
+      microchip {['9'+Faker::Number.number(digits: 14).to_s, Faker::Alphanumeric.alphanumeric(number: 10).to_s].sample }
       age { Cat::AGES.sample }
       size { Cat::SIZES.sample }
       gender { Cat::GENDERS.sample }

--- a/spec/factories/dog.rb
+++ b/spec/factories/dog.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     }
     status {  Dog::STATUSES.sample }
     hidden { false }
-    sequence(:microchip) { |n| "MC-#{n}" }
+    microchip {['9'+Faker::Number.number(digits: 14).to_s, Faker::Alphanumeric.alphanumeric(number: 10).to_s].sample }
     age { Dog::AGES.sample }
     size { Dog::SIZES.sample }
     gender { Dog::GENDERS.sample }

--- a/spec/features/cat/add_cat_spec.rb
+++ b/spec/features/cat/add_cat_spec.rb
@@ -100,7 +100,7 @@ feature 'add a cat', js: true do
         fill_in(:cat_flea_tick_preventative, with: 'born in a barn')
         fill_in(:cat_dewormer, with: 'duis aute')
         fill_in(:cat_coccidia_treatment, with: 'have a nice day')
-        fill_in(:cat_microchip, with: '1234abcd')
+        fill_in(:cat_microchip, with: '923456789a')
         fill_in(:cat_original_name, with: 'Snoop Catt')
         fill_in(:cat_fee, with: '333')
         select(adoption_coordinator.name, from: 'cat_coordinator_id')
@@ -172,7 +172,7 @@ feature 'add a cat', js: true do
         expect(cat.flea_tick_preventative).to eq 'born in a barn'
         expect(cat.dewormer).to eq 'duis aute'
         expect(cat.coccidia_treatment).to eq 'have a nice day'
-        expect(cat.microchip).to eq '1234abcd'
+        expect(cat.microchip).to eq '923456789a'
         expect(cat.original_name).to eq 'Snoop Catt'
         expect(cat.fee).to eq 333
         expect(cat.coordinator_id).to eq adoption_coordinator.id
@@ -361,8 +361,8 @@ feature 'add a cat', js: true do
     #uniqueness of name validated on server
     context 'user enters invalid attributes --server-side validation' do
       let!(:fido){ create(:cat, name: "Fido") }
-
-      context 'when the user adds a dog with a duplicate name' do
+      
+      context 'when the user adds a cat with a duplicate name' do
         it 'should not save and should notify the user' do
           visit new_cats_manager_path
           fill_in(:cat_name, with: 'fido')

--- a/spec/features/cat/edit_cat_spec.rb
+++ b/spec/features/cat/edit_cat_spec.rb
@@ -179,7 +179,7 @@ feature 'edit a cat', js: true do
         fill_in(:cat_flea_tick_preventative, with: 'words')
         fill_in(:cat_dewormer, with: 'duis aute')
         fill_in(:cat_coccidia_treatment, with: 'excepteur sint')
-        fill_in(:cat_microchip, with: '1234abcd')
+        fill_in(:cat_microchip, with: '923456789a')
         fill_in(:cat_original_name, with: 'Snoop Dogg')
         fill_in(:cat_fee, with: '333')
         select(adoption_coordinator.name, from: 'cat_coordinator_id')
@@ -249,7 +249,7 @@ feature 'edit a cat', js: true do
         expect(cat.flea_tick_preventative).to eq 'words'
         expect(cat.dewormer).to eq 'duis aute'
         expect(cat.coccidia_treatment).to eq 'excepteur sint'
-        expect(cat.microchip).to eq '1234abcd'
+        expect(cat.microchip).to eq '923456789a'
         expect(cat.original_name).to eq 'Snoop Dogg'
         expect(cat.fee).to eq 333
         expect(cat.coordinator_id).to eq adoption_coordinator.id
@@ -296,7 +296,7 @@ feature 'edit a cat', js: true do
         expect(page.find('#flea_tick_preventative').text).to eq 'words'
         expect(page.find('#dewormer').text).to eq 'duis aute'
         expect(page.find('#coccidia_treatment').text).to eq 'excepteur sint'
-        expect(page.find('#microchip').text).to eq '1234abcd'
+        expect(page.find('#microchip').text).to eq '923456789a'
         expect(page.find('#original_name').text).to eq 'Snoop Dogg'
         expect(page.find('#fee').text).to eq '$333'
         expect(page.find('#adoption_coordinator').text).to eq adoption_coordinator.name

--- a/spec/features/dog/add_dog_spec.rb
+++ b/spec/features/dog/add_dog_spec.rb
@@ -95,7 +95,7 @@ feature 'add a dog', js: true do
         fill_in(:dog_rabies, with: 'kablooie')
         fill_in(:dog_vac_4dx, with: 'schmutz')
         fill_in(:dog_bordetella, with: 'words')
-        fill_in(:dog_microchip, with: '1234abcd')
+        fill_in(:dog_microchip, with: '923456789a')
         fill_in(:dog_original_name, with: 'Snoop Dogg')
         fill_in(:dog_fee, with: '333')
         select(adoption_coordinator.name, from: 'dog_coordinator_id')
@@ -166,7 +166,7 @@ feature 'add a dog', js: true do
         expect(dog.rabies).to eq 'kablooie'
         expect(dog.vac_4dx).to eq 'schmutz'
         expect(dog.bordetella).to eq 'words'
-        expect(dog.microchip).to eq '1234abcd'
+        expect(dog.microchip).to eq '923456789a'
         expect(dog.original_name).to eq 'Snoop Dogg'
         expect(dog.fee).to eq 333
         expect(dog.coordinator_id).to eq adoption_coordinator.id

--- a/spec/features/dog/edit_dog_spec.rb
+++ b/spec/features/dog/edit_dog_spec.rb
@@ -176,7 +176,7 @@ feature 'edit a dog', js: true do
         fill_in(:dog_rabies, with: 'kablooie')
         fill_in(:dog_vac_4dx, with: 'schmutz')
         fill_in(:dog_bordetella, with: 'words')
-        fill_in(:dog_microchip, with: '1234abcd')
+        fill_in(:dog_microchip, with: '923456789a')
         fill_in(:dog_original_name, with: 'Snoop Dogg')
         fill_in(:dog_fee, with: '333')
         select(adoption_coordinator.name, from: 'dog_coordinator_id')
@@ -248,7 +248,7 @@ feature 'edit a dog', js: true do
         expect(dog.rabies).to eq 'kablooie'
         expect(dog.vac_4dx).to eq 'schmutz'
         expect(dog.bordetella).to eq 'words'
-        expect(dog.microchip).to eq '1234abcd'
+        expect(dog.microchip).to eq '923456789a'
         expect(dog.original_name).to eq 'Snoop Dogg'
         expect(dog.fee).to eq 333
         expect(dog.coordinator_id).to eq adoption_coordinator.id
@@ -295,7 +295,7 @@ feature 'edit a dog', js: true do
         expect(page.find('#rabies').text).to eq 'kablooie'
         expect(page.find('#vac_4dx').text).to eq 'schmutz'
         expect(page.find('#bordetella').text).to eq 'words'
-        expect(page.find('#microchip').text).to eq '1234abcd'
+        expect(page.find('#microchip').text).to eq '923456789a'
         expect(page.find('#original_name').text).to eq 'Snoop Dogg'
         expect(page.find('#fee').text).to eq '$333'
         expect(page.find('#adoption_coordinator').text).to eq adoption_coordinator.name

--- a/spec/models/cat_spec.rb
+++ b/spec/models/cat_spec.rb
@@ -155,11 +155,11 @@ describe Cat do
   end
 
   describe 'matches_microchip scope' do
-    let!(:good_cat){ create(:cat, microchip: 55) }
-    let!(:bad_cat){ create(:cat, microchip: 77) }
+    let!(:good_cat){ create(:cat, microchip: '923456789a') }
+    let!(:bad_cat){ create(:cat, microchip: '923456789b') }
 
     it 'result includes only matching tracking_id' do
-      cats = Cat.search(['55','microchip'])
+      cats = Cat.search(['923456789a','microchip'])
       expect(cats.length).to eq 1
       expect(cats).to include(good_cat)
       expect(cats).not_to include(bad_cat)

--- a/spec/models/dog_spec.rb
+++ b/spec/models/dog_spec.rb
@@ -155,11 +155,11 @@ describe Dog do
   end
 
   describe 'matches_microchip scope' do
-    let!(:good_dog){ create(:dog, microchip: 55) }
-    let!(:bad_dog){ create(:dog, microchip: 77) }
+    let!(:good_dog){ create(:dog, microchip: '923456789a') }
+    let!(:bad_dog){ create(:dog, microchip: '923456789b') }
 
     it 'result includes only matching tracking_id' do
-      dogs = Dog.search(['55','microchip'])
+      dogs = Dog.search(['923456789a','microchip'])
       expect(dogs.length).to eq 1
       expect(dogs).to include(good_dog)
       expect(dogs).not_to include(bad_dog)


### PR DESCRIPTION
## Feature 762: Microchip validation
### Changes proposed in this pull request:
* Add microchip_validation method in [dog](app/models/dog.rb) and [cat](app/models/cat.rb) models
* Add validation_class to microchip field in [dog](app/views/dogs/manager/_dog_form.html.erb) and [cat](app/views/cats/manager/_cat_form.html.erb) views
* Changed [dog](spec/factories/dog.rb) and [cat](spec/factories/cat.rb) factories to comply with microchip format
*  Changed input value of specs ([dog](spec/models/dog_spec.rb), [cat](spec/models/cat_spec.rb), [add_cat](spec/features/cat/add_cat_spec.rb), [edit_cat](spec/features/cat/edit_cat_spec.rb), [add_dog](spec/features/dog/add_dog_spec.rb) & [edit_dog](spec/features/dog/edit_dog_spec.rb)) to comply with microchip format