### PR TITLE
Fix circular argument references in adopter_searcher

### DIFF
--- a/app/controllers/adopters_controller.rb
+++ b/app/controllers/adopters_controller.rb
@@ -52,7 +52,14 @@ class AdoptersController < ApplicationController
 
   def index
     session[:last_search] = request.url
-    @adopters = AdopterSearcher.search(params: params, user_id: current_user.id)
+    if params[:show] == "MyApplications"
+      user_id = current_user.id
+    elsif params[:show] == "OpenApplications"
+      user_id = nil
+    elsif params[:show] == "AllApplications"
+      user_id = false
+    end
+    @adopters = AdopterSearcher.search(params: params, user_id: user_id)
   end
 
   def show

--- a/app/models/adopter_searcher.rb
+++ b/app/models/adopter_searcher.rb
@@ -29,18 +29,13 @@ class AdopterSearcher
 
   PHONE_CHECK = /\(?(?<areacode>[1]?[2-9]\d{2})\)?[\s-]?(?<prefix>[2-9]\d{2})[\s-]?(?<linenumber>[\d]{4})/i.freeze
 
-  def initialize(params: {}, user_id: user_id)
+  def initialize(params: {}, user_id:)
     @params = params
     @user_id = user_id
   end
 
   def search
     @adopters = Adopter
-    if @params[:show] == "MyApplications"
-      @adopters = @adopters.where(assigned_to_user_id: @user_id)
-    elsif @params[:show] == "OpenApplications"
-      @adopters = @adopters.where(assigned_to_user_id: nil)
-    end
 
     if @params[:search]
       if email_search?
@@ -65,7 +60,7 @@ class AdopterSearcher
     @adopters
   end
 
-  def self.search(params: {}, user_id: user_id)
+  def self.search(params: {}, user_id: nil)
     new(params: params, user_id: user_id).search
   end
 

--- a/spec/models/adopter_searcher_spec.rb
+++ b/spec/models/adopter_searcher_spec.rb
@@ -89,7 +89,7 @@ describe AdopterSearcher do
       let!(:user) { create(:user)}
       let!(:assigned_adopter) { create(:adopter, name: 'Frank Jones', assigned_to_user_id: user.id) }
       let!(:unassigned_adopter) { create(:adopter, name: 'Tom Jones') }
-      let!(:other_assigned_adopter) { create(:adopter, name: 'Tom Finkle, assigned_to_user_id: user.id') }
+      let!(:other_assigned_adopter) { create(:adopter, name: 'Tom Finkle', assigned_to_user_id: user.id) }
       let!(:other_unassigned_adopter) { create(:adopter, name: 'Paul Sanders') }
       let(:params) { { search: 'jones'} }
 


### PR DESCRIPTION
## Fixes #1637 

### Changes proposed on this pull request:

- Eliminates circular references
- Moves the "show" filter to [adopters_controler.rb](app/controllers/adopters_controller.rb)