### PR TITLE
fix 1665

### DIFF
--- a/app/models/adopter_searcher.rb
+++ b/app/models/adopter_searcher.rb
@@ -36,7 +36,6 @@ class AdopterSearcher
 
   def search
     @adopters = Adopter
-
     if @params[:search]
       if email_search?
         clean_email = @params[:search].strip
@@ -52,16 +51,18 @@ class AdopterSearcher
     elsif status_search?
       @adopters = @adopters.where(status: @params[:status])
     end
+    if filter_by_id? and !@params[:search]
+       @user_id == nil ? @adopters = @adopters.where(assigned_to_user_id: nil) : @adopters = @adopters.where(assigned_to_user_id: @user_id)
+    end
 
     with_includes
     with_sorting
     for_page(@params[:page])
-
     @adopters
   end
 
-  def self.search(params: {}, user_id: nil)
-    new(params: params, user_id: user_id).search
+  def self.search(params: {}, user_id:)
+      new(params: params, user_id: user_id).search
   end
 
   private
@@ -118,6 +119,10 @@ class AdopterSearcher
 
   def phone_search?
     @params[:search].match(PHONE_CHECK)
+  end
+
+  def filter_by_id?
+    (@user_id == nil or @user_id.is_a? Numeric) ? true : false
   end
 
   def format_phone(phone)

--- a/spec/models/adopter_searcher_spec.rb
+++ b/spec/models/adopter_searcher_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe AdopterSearcher do
   describe '.search' do
-    let(:results) { AdopterSearcher.search(params: params) }
+    let(:results) { AdopterSearcher.search(params: params, user_id: false) }
 
     context 'by name' do
       let!(:found_adopter) { create(:adopter, name: 'Frank') }
@@ -124,8 +124,7 @@ describe AdopterSearcher do
       let(:adopters_to_display) { AdopterSearcher.search(params: params, user_id: 1) }
       it 'filters by id when my apps is selected' do
         expect(adopters_to_display).to include(assigned_to_me)
-        expect(adopters_to_display).to_not include(assigned_to_other)
-        expect(adopters_to_display).to_not include(assigned_to_other)
+        expect(adopters_to_display).to_not include(assigned_to_other, unassigned_to)
       end
     end
 
@@ -134,8 +133,7 @@ describe AdopterSearcher do
       let(:adopters_to_display) { AdopterSearcher.search(params: params, user_id: nil) }
       it 'filters unassigned apps when open apps is selected' do
         expect(adopters_to_display).to include(unassigned_to)
-        expect(adopters_to_display).to_not include(assigned_to_me)
-        expect(adopters_to_display).to_not include(assigned_to_other)
+        expect(adopters_to_display).to_not include(assigned_to_me, assigned_to_other)
       end
     end
 
@@ -143,9 +141,7 @@ describe AdopterSearcher do
       let(:params){{show: "AllApplications"}}
       let(:adopters_to_display) { AdopterSearcher.search(params: params, user_id: false) }
       it 'show all active apps when all apps is selected' do
-        expect(adopters_to_display).to include(assigned_to_other)
-        expect(adopters_to_display).to_not include(unassigned_to)
-        expect(adopters_to_display).to_not include(assigned_to_me)
+        expect(adopters_to_display).to include(assigned_to_other, unassigned_to, assigned_to_me)
       end
     end
 


### PR DESCRIPTION
## Fix #1665 (Adopter Application Assignment Filters not filtering)
### Changes proposed
- Add `filter_by_id` method to filter applications according to user selection
- Improved spec on [adopter_searcher_spec](spec/models/adopter_searcher_spec.rb)