### PR TITLE
Feature/training to each dog adopt #1659

### DIFF
--- a/app/models/adopter.rb
+++ b/app/models/adopter.rb
@@ -200,7 +200,7 @@ class Adopter < ApplicationRecord
 
   def training_email
     return unless status_changed?
-    if ((status == 'adopted') || (status == 'adptd sn pend')) && !training_email_sent?
+    if ((status == 'adopted') || (status == 'adptd sn pend')) && !training_email_sent? && dog_or_cat == "Dog"
       TrainingMailer.free_training_notice(id).deliver_later
       self.training_email_sent = true
     end

--- a/app/models/adopter.rb
+++ b/app/models/adopter.rb
@@ -156,7 +156,7 @@ class Adopter < ApplicationRecord
       }
     end
 
-    if ((status == 'adopted') || (status == 'adptd sn pend'))
+    if (status == 'adopted' || status == 'adptd sn pend') && adoptions.any?{ |a| a.relation_type == 'adopted' } && dog_or_cat == "Dog"
       completed_date = Time.now.strftime('%m/%d/%Y')
       AdopterFollowupMailer.one_week_followup(id).deliver_later(wait: 7.days)
     else
@@ -177,7 +177,7 @@ class Adopter < ApplicationRecord
   end
 
   def chimp_check
-    return unless status_changed?
+    return unless adoptions.any?{ |a| a.relation_type_changed? }
 
     if (status == 'denied') && is_subscribed?
       chimp_unsubscribe
@@ -199,10 +199,9 @@ class Adopter < ApplicationRecord
   end
 
   def training_email
-    return unless status_changed?
-    if ((status == 'adopted') || (status == 'adptd sn pend')) && !training_email_sent? && dog_or_cat == "Dog"
+    return unless adoptions.any?{ |a| a.relation_type_changed? }
+    if (status == 'adopted' || status == 'adptd sn pend') && adoptions.any?{ |a| a.relation_type == 'adopted' } && dog_or_cat == "Dog"
       TrainingMailer.free_training_notice(id).deliver_later
-      self.training_email_sent = true
     end
   end
 

--- a/app/models/adopter.rb
+++ b/app/models/adopter.rb
@@ -156,7 +156,7 @@ class Adopter < ApplicationRecord
       }
     end
 
-    if (status == 'adopted' || status == 'adptd sn pend') && adoptions.any?{ |a| a.relation_type == 'adopted' } && dog_or_cat == "Dog"
+    if adoptions.any?{ |a| a.relation_type_changed? && a.relation_type == 'adopted' } && dog_or_cat == "Dog"
       completed_date = Time.now.strftime('%m/%d/%Y')
       AdopterFollowupMailer.one_week_followup(id).deliver_later(wait: 7.days)
     else
@@ -200,7 +200,7 @@ class Adopter < ApplicationRecord
 
   def training_email
     return unless adoptions.any?{ |a| a.relation_type_changed? }
-    if (status == 'adopted' || status == 'adptd sn pend') && adoptions.any?{ |a| a.relation_type == 'adopted' } && dog_or_cat == "Dog"
+    if adoptions.any?{ |a| a.relation_type == 'adopted' } && dog_or_cat == "Dog"
       TrainingMailer.free_training_notice(id).deliver_later
     end
   end

--- a/app/models/adopter.rb
+++ b/app/models/adopter.rb
@@ -177,7 +177,7 @@ class Adopter < ApplicationRecord
   end
 
   def chimp_check
-    return unless adoptions.any?{ |a| a.relation_type_changed? }
+    return unless status_changed? || adoptions.any?{ |a| a.relation_type_changed? }
 
     if (status == 'denied') && is_subscribed?
       chimp_unsubscribe

--- a/spec/controllers/adopters_controller_spec.rb
+++ b/spec/controllers/adopters_controller_spec.rb
@@ -105,12 +105,22 @@ describe AdoptersController, type: :controller do
     end
   end
 
-  describe 'Adopter recept of Training Coupon and followup email' do
+  describe 'Adopter receipt of Training Coupon and followup email' do
     include ActiveJob::TestHelper
     include_context 'signed in admin'
 
+    context 'cat adopter test training email' do
+      let(:adopter) { create(:adopter, :with_app, dog_or_cat: 'Cat', status: 'approved') }
+      it 'cat adopter does not create training email' do
+        ActiveJob::Base.queue_adapter = :test
+        expect do 
+          put :update, params: { id: adopter.id, adopter: { status: 'adopted' } }
+        end.not_to have_enqueued_job.with("TrainingMailer","free_training_notice","deliver_now", adopter.id)
+      end
+    end
+ 
     context 'adopter set to adopted status for the first time' do
-      let(:adopter) { create(:adopter, :with_app, status: 'approved') }
+      let(:adopter) { create(:adopter, :with_app, dog_or_cat: 'Dog', status: 'approved') }
       it 'free training coupon email created' do
         ActiveJob::Base.queue_adapter = :test
         expect do

--- a/spec/controllers/adopters_controller_spec.rb
+++ b/spec/controllers/adopters_controller_spec.rb
@@ -110,62 +110,53 @@ describe AdoptersController, type: :controller do
     include_context 'signed in admin'
 
     context 'cat adopter test training email' do
-      let(:adopter) { create(:adopter, :with_app, dog_or_cat: 'Cat', status: 'approved') }
+      let(:adopter) { create(:adopter, :with_app, status: 'adopted', dog_or_cat: 'Cat', adoptions_attributes: [{ relation_type: 'interested' }]) }
+      
       it 'cat adopter does not create training email' do
         ActiveJob::Base.queue_adapter = :test
         expect do 
-          put :update, params: { id: adopter.id, adopter: { status: 'adopted' } }
+          adopter.update_attributes(adoptions_attributes: [{ id: adopter.adoptions.first.id, relation_type: 'adopted' }])
         end.not_to have_enqueued_job.with("TrainingMailer","free_training_notice","deliver_now", adopter.id)
       end
+
+      it 'returns proper relation_type' do
+        adopter.update_attributes(adoptions_attributes: [{ id: adopter.adoptions.first.id, relation_type: 'adopted' }])
+        expect(adopter.adoptions.first.relation_type).to eq("adopted")
+      end
+
     end
  
     context 'adopter set to adopted status for the first time' do
-      let(:adopter) { create(:adopter, :with_app, dog_or_cat: 'Dog', status: 'approved') }
+      let(:adopter) { create(:adopter, :with_app, status: 'adopted', dog_or_cat: 'Dog', adoptions_attributes: [{ relation_type: 'interested' }]) }
+      
       it 'free training coupon email created' do
         ActiveJob::Base.queue_adapter = :test
         expect do
-          put :update, params: { id: adopter.id, adopter: { status: 'adopted' } }
+          adopter.update_attributes(adoptions_attributes: [{ id: adopter.adoptions.first.id, relation_type: 'adopted' }])
         end.to have_enqueued_job.with("TrainingMailer","free_training_notice","deliver_now", adopter.id)
       end
 
       it 'one week followup email created' do
         ActiveJob::Base.queue_adapter = :test
         expect do
-          put :update, params: { id: adopter.id, adopter: { status: 'adopted' } }
+          adopter.update_attributes(adoptions_attributes: [{ id: adopter.adoptions.first.id, relation_type: 'adopted' }])
         end.to have_enqueued_job.with("AdopterFollowupMailer","one_week_followup","deliver_now", adopter.id)
       end
 
       it 'free training coupon and one week followup is sent' do
         expect do
           perform_enqueued_jobs do
-            put :update, params: { id: adopter.id, adopter: { status: 'adopted' } }
+            adopter.update_attributes(adoptions_attributes: [{ id: adopter.adoptions.first.id, relation_type: 'adopted' }])
           end
         end.to change { ActionMailer::Base.deliveries.size }.by(2)
       end
 
       it 'free training coupon and one week followup is set to the right adopter' do
         perform_enqueued_jobs do
-          put :update, params: { id: adopter.id, adopter: { status: 'adopted' } }
+          adopter.update_attributes(adoptions_attributes: [{ id: adopter.adoptions.first.id, relation_type: 'adopted' }])
         end
         mail = ActionMailer::Base.deliveries.last
         expect(mail.to[0]).to eq adopter.email
-      end
-
-      it 'training_email_sent is set to true' do
-        put :update, params: { id: adopter.id, adopter: { status: 'adopted' } }
-        expect(adopter.reload.training_email_sent).to eq true
-      end
-    end
-
-    context 'adopter has already been sent training email' do
-      let(:adopter) { create(:adopter, :with_app, status: 'approved', training_email_sent: true) }
-
-      it 'free training coupon is not sent but one week followup is sent' do
-        expect do
-          perform_enqueued_jobs do
-            put :update, params: { id: adopter.id, adopter: { status: 'adopted' } }
-          end
-        end.to change { ActionMailer::Base.deliveries.size }.by(1)
       end
     end
   end


### PR DESCRIPTION
app/models/adopter.rb
- Training email now triggers off of changing relation_type to "adopted" && Dog adoptions only 
- Chimp check triggers off status change or relation_type change
- Followup email triggers off of changing relation_type to "adopted" && Dog adoptions only
spec/controllers/adopters_controller_spec.rb
- tests changed to prove emails trigger from relation_type change not status change
- added test to prove cat adoptions do not trigger training / followup emails
- added test to prove 2 emails sent per adoption 

closes #1659 