### PR TITLE
Don't show medical info on pet bios

### DIFF
--- a/app/helpers/about_animal_helper.rb
+++ b/app/helpers/about_animal_helper.rb
@@ -1,20 +1,16 @@
 module AboutAnimalHelper
   def some_details(animal)
     @animal = animal
-    [animal.name, first_sentence, second_sentence, third_sentence].join(' ')
+    [animal.name, first_sentence, second_sentence].join(' ')
   end
 
   private
 
   def first_sentence
-    [up_to_date_on_shots, spay_or_neuter_status].to_sentence_period
-  end
-
-  def second_sentence
     "#{pronoun} #{caveats.to_sentence_period}" if caveats.any?
   end
 
-  def third_sentence
+  def second_sentence
     "#{@animal.name} is currently being fostered in #{@animal.foster_location}." if @animal.foster_location
   end
 
@@ -28,22 +24,8 @@ module AboutAnimalHelper
     caveats
   end
 
-  def spay_or_neuter_status
-    not_yet = not_yet(@animal.is_altered)
-    "has #{not_yet} been #{spayed_or_neutered}"
-  end
-
-  def up_to_date_on_shots
-    not_yet = not_yet(@animal.is_uptodateonshots)
-    "is #{not_yet} up-to-date on #{posessive_pronoun} vaccinations"
-  end
-
   def not_yet(is_true)
     is_true ? "" : "not yet"
-  end
-
-  def spayed_or_neutered
-    @animal.gender == "Male" ? "neutered" : "spayed"
   end
 
   def posessive_pronoun


### PR DESCRIPTION
Remove shot and spay/neuter info from public profile as it can be confusing.  Per OPH request.