### PR TITLE
Fix devcontainer bundle_cache volume colliding with new Ruby version …

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -7,7 +7,7 @@ services:
         RUBY_VERSION: "3.3.12"
     volumes:
       - ..:/workspace:cached
-      - bundle_cache:/usr/local/rbenv/versions/3.3.12/lib/ruby/gems
+      - bundle_cache_3_3_12:/usr/local/rbenv/versions/3.3.12/lib/ruby/gems
     command: sleep infinity
     depends_on:
       - db
@@ -41,4 +41,4 @@ services:
 
 volumes:
   pg_data:
-  bundle_cache:
+  bundle_cache_3_3_12:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,21 @@ stays 7.1.6): DONE**
   already installed via rbenv — not exercised by this session's
   verification, flagged in the PR description as a pre-deploy
   prerequisite.
+- **Post-merge devcontainer rebuild caught a real bug in the above**:
+  `.devcontainer/compose.yaml`'s `bundle_cache` named volume was never
+  version-qualified, only its mount path was. Docker only auto-populates
+  a named volume from the image's build-time content the *first* time
+  that volume is created empty; the pre-existing `bundle_cache` volume
+  (populated with Ruby 3.0.5's gems from before this pass) got
+  remounted as-is onto the new `.../3.3.12/lib/ruby/gems` path, hiding
+  the `bundler` gem the Dockerfile installs into the image at that same
+  path — surfacing as `postCreateCommand`'s `bundle install` failing
+  with `Gem::GemNotFoundException: can't find gem bundler`. Fixed by
+  renaming the volume itself to `bundle_cache_3_3_12` (both the service
+  mount and the top-level `volumes:` entry), so each Ruby version gets
+  its own cache volume and this can't recur on the next Ruby bump. The
+  old orphaned `bundle_cache` volume is harmless to leave in place
+  (just unused disk) or can be pruned with `docker volume rm`.
 - Explicitly deferred/out of scope for this pass (same list as Passes 1
   and 2, still true, not yet addressed): Webpacker replacement,
   kt-paperclip → ActiveStorage migration, Unicorn/Puma reconciliation,


### PR DESCRIPTION
…path

Rebuilding the devcontainer after the Ruby 3.3.12 bump failed postCreateCommand's `bundle install` with
`Gem::GemNotFoundException: can't find gem bundler`. The `bundle_cache` named volume was never version-qualified, only its mount path was. Docker only auto-populates a named volume from the image's build-time content the first time that volume is created empty; the pre-existing `bundle_cache` volume (holding Ruby 3.0.5's gems from before the Ruby upgrade) got remounted as-is onto the new
.../3.3.12/lib/ruby/gems path, hiding the `bundler` gem the Dockerfile installs into the image at that same path during build.

Renamed the volume itself to `bundle_cache_3_3_12` (service mount and top-level volumes: entry) so each Ruby version gets its own cache volume and this can't recur on the next bump. The orphaned old `bundle_cache` volume is harmless to leave (unused disk) or can be removed with `docker volume rm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Development Experience**
  * Updated the development container’s Ruby gem cache to use a version-specific volume.
  * Documented the required cache reset and rebuild guidance for Ruby version upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->